### PR TITLE
Upgraded Go to 1.13.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 go:
-  # TODO Upgrade to 1.13 https://github.com/aquasecurity/harbor-scanner-trivy/issues/24
-  - "1.12"
+  - "1.13"
 
 git:
   depth: 1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aquasecurity/harbor-scanner-trivy
 
-go 1.12
+go 1.13
 
 require (
 	github.com/Microsoft/hcsshim v0.8.6 // indirect


### PR DESCRIPTION
It compiles properly and the tests run successfully.

```
GO111MODULE=on go test -short -race -coverprofile=coverage.txt -covermode=atomic ./...
?       github.com/aquasecurity/harbor-scanner-trivy/cmd/scanner-trivy  [no test files]
ok      github.com/aquasecurity/harbor-scanner-trivy/pkg/etc    1.013s  coverage: 100.0% of statements
ok      github.com/aquasecurity/harbor-scanner-trivy/pkg/http/api       1.015s  coverage: 76.5% of statements
ok      github.com/aquasecurity/harbor-scanner-trivy/pkg/http/api/v1    1.012s  coverage: 13.2% of statements
ok      github.com/aquasecurity/harbor-scanner-trivy/pkg/model  1.011s  coverage: 0.0% of statements [no tests to run]
?       github.com/aquasecurity/harbor-scanner-trivy/pkg/model/harbor   [no test files]
?       github.com/aquasecurity/harbor-scanner-trivy/pkg/model/job      [no test files]
?       github.com/aquasecurity/harbor-scanner-trivy/pkg/model/trivy    [no test files]
?       github.com/aquasecurity/harbor-scanner-trivy/pkg/queue  [no test files]
ok      github.com/aquasecurity/harbor-scanner-trivy/pkg/scan   1.016s  coverage: 28.3% of statements
?       github.com/aquasecurity/harbor-scanner-trivy/pkg/store  [no test files]
?       github.com/aquasecurity/harbor-scanner-trivy/pkg/store/redis    [no test files]
?       github.com/aquasecurity/harbor-scanner-trivy/pkg/trivy  [no test files]
```