### PR TITLE
test: Add unit tests for scanner controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,5 +16,4 @@ require (
 	github.com/testcontainers/testcontainers-go v0.0.8
 	golang.org/x/net v0.0.0-20180906233101-161cd47e91fd
 	golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7
-	gotest.tools v0.0.0-20181223230014-1083505acf35
 )

--- a/pkg/http/api/base_handler_test.go
+++ b/pkg/http/api/base_handler_test.go
@@ -1,11 +1,12 @@
 package api
 
 import (
-	"github.com/aquasecurity/harbor-scanner-trivy/pkg/model/harbor"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/aquasecurity/harbor-scanner-trivy/pkg/model/harbor"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMimeType_String(t *testing.T) {
@@ -47,4 +48,14 @@ func TestBaseHandler_WriteJSONError(t *testing.T) {
 	// then
 	assert.Equal(t, http.StatusBadRequest, recorder.Code)
 	assert.JSONEq(t, `{"error":{"message":"Invalid request"}}`, recorder.Body.String())
+}
+
+func TestBaseHandler_SendInternalServerError(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	handler := &BaseHandler{}
+
+	handler.SendInternalServerError(recorder)
+
+	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+	assert.Equal(t, "Internal Server Error\n", recorder.Body.String())
 }

--- a/pkg/http/api/v1/handler.go
+++ b/pkg/http/api/v1/handler.go
@@ -178,7 +178,7 @@ func (h *requestHandler) GetScanReport(res http.ResponseWriter, req *http.Reques
 		return
 	}
 
-	h.WriteJSON(res, scanJob.Reports.HarborScanReport, api.MimeTypeHarborVulnerabilityReport, http.StatusOK)
+	h.WriteJSON(res, scanJob.Report, api.MimeTypeHarborVulnerabilityReport, http.StatusOK)
 }
 
 func (h *requestHandler) GetMetadata(res http.ResponseWriter, req *http.Request) {

--- a/pkg/http/api/v1/handler_test.go
+++ b/pkg/http/api/v1/handler_test.go
@@ -277,30 +277,28 @@ func TestRequestHandler_GetScanReport(t *testing.T) {
 				ReturnArgs: []interface{}{&job.ScanJob{
 					ID:     "job:123",
 					Status: job.Finished,
-					Reports: job.ScanReports{
-						HarborScanReport: harbor.ScanResult{
-							GeneratedAt: now,
-							Artifact: harbor.Artifact{
-								Repository: "library/mongo",
-								Digest:     "sha256:6c3c624b58dbbcd3c0dd82b4c53f04194d1247c6eebdaab7c610cf7d66709b3b",
-							},
-							Scanner: harbor.Scanner{
-								Name:    "Trivy",
-								Vendor:  "Aqua Security",
-								Version: "0.1.6",
-							},
-							Severity: harbor.SevCritical,
-							Vulnerabilities: []harbor.VulnerabilityItem{
-								{
-									ID:          "CVE-2019-1111",
-									Pkg:         "openssl",
-									Version:     "2.0-rc1",
-									FixVersion:  "2.1",
-									Severity:    harbor.SevCritical,
-									Description: "You'd better upgrade your server",
-									Links: []string{
-										"http://cve.com?id=CVE-2019-1111",
-									},
+					Report: harbor.ScanReport{
+						GeneratedAt: now,
+						Artifact: harbor.Artifact{
+							Repository: "library/mongo",
+							Digest:     "sha256:6c3c624b58dbbcd3c0dd82b4c53f04194d1247c6eebdaab7c610cf7d66709b3b",
+						},
+						Scanner: harbor.Scanner{
+							Name:    "Trivy",
+							Vendor:  "Aqua Security",
+							Version: "0.1.6",
+						},
+						Severity: harbor.SevCritical,
+						Vulnerabilities: []harbor.VulnerabilityItem{
+							{
+								ID:          "CVE-2019-1111",
+								Pkg:         "openssl",
+								Version:     "2.0-rc1",
+								FixVersion:  "2.1",
+								Severity:    harbor.SevCritical,
+								Description: "You'd better upgrade your server",
+								Links: []string{
+									"http://cve.com?id=CVE-2019-1111",
 								},
 							},
 						},

--- a/pkg/mock/expectation.go
+++ b/pkg/mock/expectation.go
@@ -26,6 +26,16 @@ func ApplyExpectations(t *testing.T, mock interface{}, expectations ...*Expectat
 		for _, e := range expectations {
 			m.On(e.Method, e.Args...).Return(e.ReturnArgs...)
 		}
+	case *Wrapper:
+		m := mock.(*Wrapper)
+		for _, e := range expectations {
+			m.On(e.Method, e.Args...).Return(e.ReturnArgs...)
+		}
+	case *Transformer:
+		m := mock.(*Transformer)
+		for _, e := range expectations {
+			m.On(e.Method, e.Args...).Return(e.ReturnArgs...)
+		}
 	default:
 		t.Fatalf("Unrecognized mock type: %T!", v)
 	}

--- a/pkg/mock/store.go
+++ b/pkg/mock/store.go
@@ -1,6 +1,7 @@
 package mock
 
 import (
+	"github.com/aquasecurity/harbor-scanner-trivy/pkg/model/harbor"
 	"github.com/aquasecurity/harbor-scanner-trivy/pkg/model/job"
 	"github.com/stretchr/testify/mock"
 )
@@ -28,7 +29,7 @@ func (s *Store) UpdateStatus(scanJobID string, newStatus job.ScanJobStatus, erro
 	return args.Error(0)
 }
 
-func (s *Store) UpdateReports(scanJobID string, reports job.ScanReports) error {
-	args := s.Called(scanJobID, reports)
+func (s *Store) UpdateReport(scanJobID string, report harbor.ScanReport) error {
+	args := s.Called(scanJobID, report)
 	return args.Error(0)
 }

--- a/pkg/mock/transformer.go
+++ b/pkg/mock/transformer.go
@@ -1,0 +1,20 @@
+package mock
+
+import (
+	"github.com/aquasecurity/harbor-scanner-trivy/pkg/model/harbor"
+	"github.com/aquasecurity/harbor-scanner-trivy/pkg/model/trivy"
+	"github.com/stretchr/testify/mock"
+)
+
+type Transformer struct {
+	mock.Mock
+}
+
+func NewTransformer() *Transformer {
+	return &Transformer{}
+}
+
+func (t *Transformer) Transform(artifact harbor.Artifact, source trivy.ScanResult) harbor.ScanReport {
+	args := t.Called(artifact, source)
+	return args.Get(0).(harbor.ScanReport)
+}

--- a/pkg/mock/wrapper.go
+++ b/pkg/mock/wrapper.go
@@ -1,0 +1,20 @@
+package mock
+
+import (
+	model "github.com/aquasecurity/harbor-scanner-trivy/pkg/model/trivy"
+	"github.com/aquasecurity/harbor-scanner-trivy/pkg/trivy"
+	"github.com/stretchr/testify/mock"
+)
+
+type Wrapper struct {
+	mock.Mock
+}
+
+func NewWrapper() *Wrapper {
+	return &Wrapper{}
+}
+
+func (w *Wrapper) Run(imageRef string, auth trivy.RegistryAuth) (model.ScanResult, error) {
+	args := w.Called(imageRef, auth)
+	return args.Get(0).(model.ScanResult), args.Error(1)
+}

--- a/pkg/model/harbor/model.go
+++ b/pkg/model/harbor/model.go
@@ -3,6 +3,9 @@ package harbor
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
+	"golang.org/x/xerrors"
+	"net/url"
 	"time"
 )
 
@@ -74,11 +77,21 @@ type ScanRequest struct {
 	Artifact Artifact `json:"artifact"`
 }
 
+// GetImageRef returns Docker image reference for this ScanRequest.
+// Example: core.harbor.domain/scanners/mysql@sha256:3b00a364fb74246ca119d16111eb62f7302b2ff66d51e373c2bb209f8a1f3b9e
+func (c ScanRequest) GetImageRef() (string, error) {
+	registryURL, err := url.Parse(c.Registry.URL)
+	if err != nil {
+		return "", xerrors.Errorf("parsing registry URL: %w", err)
+	}
+	return fmt.Sprintf("%s/%s@%s", registryURL.Host, c.Artifact.Repository, c.Artifact.Digest), nil
+}
+
 type ScanResponse struct {
 	ID string `json:"id"`
 }
 
-type ScanResult struct {
+type ScanReport struct {
 	GeneratedAt     time.Time           `json:"generated_at"`
 	Artifact        Artifact            `json:"artifact"`
 	Scanner         Scanner             `json:"scanner"`

--- a/pkg/model/harbor/model_test.go
+++ b/pkg/model/harbor/model_test.go
@@ -1,0 +1,55 @@
+package harbor
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestScanRequest_GetImageRef(t *testing.T) {
+	testCases := []struct {
+		Request  ScanRequest
+		ImageRef string
+	}{
+		{
+			Request: ScanRequest{
+				Registry: Registry{
+					URL: "https://core.harbor.domain",
+				},
+				Artifact: Artifact{
+					Repository: "library/mongo",
+					Digest:     "test:ABC",
+				},
+			},
+			ImageRef: "core.harbor.domain/library/mongo@test:ABC",
+		},
+		{
+			Request: ScanRequest{
+				Registry: Registry{
+					URL: "https://core.harbor.domain:443",
+				},
+				Artifact: Artifact{Repository: "library/nginx",
+					Digest: "test:DEF",
+				},
+			},
+			ImageRef: "core.harbor.domain:443/library/nginx@test:DEF",
+		},
+		{
+			Request: ScanRequest{
+				Registry: Registry{
+					URL: "http://harbor-harbor-registry:5000",
+				},
+				Artifact: Artifact{
+					Repository: "scanners/mongo",
+					Digest:     "test:GHI",
+				},
+			},
+			ImageRef: "harbor-harbor-registry:5000/scanners/mongo@test:GHI",
+		},
+	}
+	for _, tc := range testCases {
+		imageRef, err := tc.Request.GetImageRef()
+		require.NoError(t, err)
+		assert.Equal(t, tc.ImageRef, imageRef)
+	}
+}

--- a/pkg/model/harbor/model_test.go
+++ b/pkg/model/harbor/model_test.go
@@ -1,17 +1,20 @@
 package harbor
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestScanRequest_GetImageRef(t *testing.T) {
 	testCases := []struct {
-		Request  ScanRequest
-		ImageRef string
+		name          string
+		Request       ScanRequest
+		ImageRef      string
+		expectedError string
 	}{
 		{
+			name: "mongo",
 			Request: ScanRequest{
 				Registry: Registry{
 					URL: "https://core.harbor.domain",
@@ -24,6 +27,7 @@ func TestScanRequest_GetImageRef(t *testing.T) {
 			ImageRef: "core.harbor.domain/library/mongo@test:ABC",
 		},
 		{
+			name: "nginx",
 			Request: ScanRequest{
 				Registry: Registry{
 					URL: "https://core.harbor.domain:443",
@@ -35,6 +39,7 @@ func TestScanRequest_GetImageRef(t *testing.T) {
 			ImageRef: "core.harbor.domain:443/library/nginx@test:DEF",
 		},
 		{
+			name: "harbor",
 			Request: ScanRequest{
 				Registry: Registry{
 					URL: "http://harbor-harbor-registry:5000",
@@ -46,10 +51,24 @@ func TestScanRequest_GetImageRef(t *testing.T) {
 			},
 			ImageRef: "harbor-harbor-registry:5000/scanners/mongo@test:GHI",
 		},
+		{
+			name: "invalid registry url",
+			Request: ScanRequest{
+				Registry: Registry{
+					URL: `"http://foo%bar@www.example.com/"`,
+				},
+			},
+			expectedError: `parsing registry URL: parse "http://foo%bar@www.example.com/": first path segment in URL cannot contain colon`,
+		},
 	}
 	for _, tc := range testCases {
 		imageRef, err := tc.Request.GetImageRef()
-		require.NoError(t, err)
-		assert.Equal(t, tc.ImageRef, imageRef)
+		switch {
+		case tc.expectedError != "":
+			assert.Equal(t, tc.expectedError, err.Error(), tc.name)
+		default:
+			assert.NoError(t, err, tc.name)
+		}
+		assert.Equal(t, tc.ImageRef, imageRef, tc.name)
 	}
 }

--- a/pkg/model/harbor/model_test.go
+++ b/pkg/model/harbor/model_test.go
@@ -109,5 +109,38 @@ func TestSeverity_MarshalJSON(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, `"`+tc.expectedSeverity.String()+`"`, string(b))
 	}
+}
+
+func TestSeverity_UnmarshalJSON(t *testing.T) {
+	testCases := []struct {
+		inputSeverityJSON string
+		expectedSeverity  string
+		expectedError     string
+	}{
+		{
+			inputSeverityJSON: `"Unknown"`,
+			expectedSeverity:  "Unknown",
+		},
+		{
+			inputSeverityJSON: `"Medium"`,
+			expectedSeverity:  "Medium",
+		},
+		{
+			inputSeverityJSON: `invalid json input`,
+			expectedError:     "invalid character 'i' looking for beginning of value",
+		},
+	}
+
+	for _, tc := range testCases {
+		var s Severity
+		err := s.UnmarshalJSON([]byte(tc.inputSeverityJSON))
+		switch {
+		case tc.expectedError != "":
+			assert.Equal(t, tc.expectedError, err.Error())
+		default:
+			assert.NoError(t, err)
+		}
+		assert.Equal(t, tc.expectedSeverity, s.String())
+	}
 
 }

--- a/pkg/model/harbor/model_test.go
+++ b/pkg/model/harbor/model_test.go
@@ -72,3 +72,42 @@ func TestScanRequest_GetImageRef(t *testing.T) {
 		assert.Equal(t, tc.ImageRef, imageRef, tc.name)
 	}
 }
+
+func TestSeverity_MarshalJSON(t *testing.T) {
+	testCases := []struct {
+		severityLevel    int
+		expectedSeverity Severity
+	}{
+		{
+			severityLevel:    1,
+			expectedSeverity: SevUnknown,
+		},
+		{
+			severityLevel:    2,
+			expectedSeverity: SevLow,
+		},
+		{
+			severityLevel:    3,
+			expectedSeverity: SevMedium,
+		},
+		{
+			severityLevel:    4,
+			expectedSeverity: SevHigh,
+		},
+		{
+			severityLevel:    5,
+			expectedSeverity: SevCritical,
+		},
+		{
+			severityLevel: 666,
+		},
+	}
+
+	for _, tc := range testCases {
+		s := Severity(tc.severityLevel)
+		b, err := s.MarshalJSON()
+		assert.NoError(t, err)
+		assert.Equal(t, `"`+tc.expectedSeverity.String()+`"`, string(b))
+	}
+
+}

--- a/pkg/model/job/model.go
+++ b/pkg/model/job/model.go
@@ -2,7 +2,6 @@ package job
 
 import (
 	"github.com/aquasecurity/harbor-scanner-trivy/pkg/model/harbor"
-	"github.com/aquasecurity/harbor-scanner-trivy/pkg/model/trivy"
 )
 
 type ScanJobStatus int
@@ -22,13 +21,8 @@ func (s ScanJobStatus) String() string {
 }
 
 type ScanJob struct {
-	ID      string        `json:"id"`
-	Status  ScanJobStatus `json:"status"`
-	Error   string        `json:"error"`
-	Reports ScanReports   `json:"reports"`
-}
-
-type ScanReports struct {
-	TrivyScanReport  trivy.ScanResult  `json:"trivy_scan_report"`
-	HarborScanReport harbor.ScanResult `json:"harbor-scan_report"`
+	ID     string            `json:"id"`
+	Status ScanJobStatus     `json:"status"`
+	Error  string            `json:"error"`
+	Report harbor.ScanReport `json:"report"`
 }

--- a/pkg/model/transformer.go
+++ b/pkg/model/transformer.go
@@ -24,7 +24,7 @@ func (c *SystemClock) Now() time.Time {
 // Transformer wraps the Transform method.
 // Transform transforms Trivy's scan report into Harbor's packages vulnerabilities report.
 type Transformer interface {
-	Transform(artifact harbor.Artifact, source trivy.ScanResult) harbor.ScanResult
+	Transform(artifact harbor.Artifact, source trivy.ScanResult) harbor.ScanReport
 }
 
 type transformer struct {
@@ -38,7 +38,7 @@ func NewTransformer(clock Clock) Transformer {
 	}
 }
 
-func (t *transformer) Transform(artifact harbor.Artifact, source trivy.ScanResult) (target harbor.ScanResult) {
+func (t *transformer) Transform(artifact harbor.Artifact, source trivy.ScanResult) (target harbor.ScanReport) {
 	var vulnerabilities []harbor.VulnerabilityItem
 
 	for _, v := range source.Vulnerabilities {
@@ -53,7 +53,7 @@ func (t *transformer) Transform(artifact harbor.Artifact, source trivy.ScanResul
 		})
 	}
 
-	target = harbor.ScanResult{
+	target = harbor.ScanReport{
 		GeneratedAt:     t.clock.Now(),
 		Scanner:         etc.GetScannerMetadata(),
 		Artifact:        artifact,

--- a/pkg/model/transformer_test.go
+++ b/pkg/model/transformer_test.go
@@ -1,11 +1,12 @@
 package model
 
 import (
+	"testing"
+	"time"
+
 	"github.com/aquasecurity/harbor-scanner-trivy/pkg/model/harbor"
 	"github.com/aquasecurity/harbor-scanner-trivy/pkg/model/trivy"
 	"github.com/stretchr/testify/assert"
-	"testing"
-	"time"
 )
 
 type fixedClock struct {
@@ -78,6 +79,12 @@ func TestTransformer_Transform(t *testing.T) {
 				InstalledVersion: "PKG-05-VER",
 				Severity:         "~~~UNKNOWN~~~",
 			},
+			{
+				VulnerabilityID:  "CVE-0000-0006",
+				PkgName:          "PKG-06",
+				InstalledVersion: "PKG-06-VER",
+				Severity:         "UNKNOWN",
+			},
 		},
 	})
 	assert.Equal(t, harbor.ScanReport{
@@ -142,6 +149,13 @@ func TestTransformer_Transform(t *testing.T) {
 				ID:       "CVE-0000-0005",
 				Pkg:      "PKG-05",
 				Version:  "PKG-05-VER",
+				Severity: harbor.SevUnknown,
+				Links:    []string{},
+			},
+			{
+				ID:       "CVE-0000-0006",
+				Pkg:      "PKG-06",
+				Version:  "PKG-06-VER",
 				Severity: harbor.SevUnknown,
 				Links:    []string{},
 			},

--- a/pkg/model/transformer_test.go
+++ b/pkg/model/transformer_test.go
@@ -80,7 +80,7 @@ func TestTransformer_Transform(t *testing.T) {
 			},
 		},
 	})
-	assert.Equal(t, harbor.ScanResult{
+	assert.Equal(t, harbor.ScanReport{
 		GeneratedAt: fixedTime,
 		Artifact: harbor.Artifact{
 			Repository: "library/mongo",

--- a/pkg/scan/controller.go
+++ b/pkg/scan/controller.go
@@ -2,7 +2,6 @@ package scan
 
 import (
 	"encoding/base64"
-	"fmt"
 	"github.com/aquasecurity/harbor-scanner-trivy/pkg/model"
 	"github.com/aquasecurity/harbor-scanner-trivy/pkg/model/harbor"
 	"github.com/aquasecurity/harbor-scanner-trivy/pkg/model/job"
@@ -10,7 +9,6 @@ import (
 	"github.com/aquasecurity/harbor-scanner-trivy/pkg/trivy"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/xerrors"
-	"net/url"
 	"strings"
 )
 
@@ -56,7 +54,7 @@ func (c *controller) scan(scanJobID string, req harbor.ScanRequest) (err error) 
 		return xerrors.Errorf("updating scan job status: %v", err)
 	}
 
-	imageRef, err := c.ToImageRef(req)
+	imageRef, err := req.GetImageRef()
 	if err != nil {
 		return err
 	}
@@ -71,13 +69,9 @@ func (c *controller) scan(scanJobID string, req harbor.ScanRequest) (err error) 
 		return xerrors.Errorf("running trivy wrapper: %v", err)
 	}
 
-	err = c.dataStore.UpdateReports(scanJobID, job.ScanReports{
-		TrivyScanReport:  scanReport,
-		HarborScanReport: c.transformer.Transform(req.Artifact, scanReport),
-	})
-
+	err = c.dataStore.UpdateReport(scanJobID, c.transformer.Transform(req.Artifact, scanReport))
 	if err != nil {
-		return xerrors.Errorf("saving scan reports: %v", err)
+		return xerrors.Errorf("saving scan report: %v", err)
 	}
 
 	err = c.dataStore.UpdateStatus(scanJobID, job.Finished)
@@ -88,16 +82,6 @@ func (c *controller) scan(scanJobID string, req harbor.ScanRequest) (err error) 
 	return
 }
 
-// ToImageRef returns Docker image reference for the given ScanRequest.
-// Example: core.harbor.domain/scanners/mysql@sha256:3b00a364fb74246ca119d16111eb62f7302b2ff66d51e373c2bb209f8a1f3b9e
-func (c *controller) ToImageRef(req harbor.ScanRequest) (string, error) {
-	registryURL, err := url.Parse(req.Registry.URL)
-	if err != nil {
-		return "", xerrors.Errorf("parsing registry URL: %w", err)
-	}
-	return fmt.Sprintf("%s/%s@%s", registryURL.Host, req.Artifact.Repository, req.Artifact.Digest), nil
-}
-
 func (c *controller) ToRegistryAuth(authorization string) (auth trivy.RegistryAuth, err error) {
 	tokens := strings.Split(authorization, " ")
 	if len(tokens) != 2 {
@@ -105,12 +89,12 @@ func (c *controller) ToRegistryAuth(authorization string) (auth trivy.RegistryAu
 	}
 	switch tokens[0] {
 	case "Basic":
-		return c.encodeBasicAuth(tokens[1])
+		return c.decodeBasicAuth(tokens[1])
 	}
 	return auth, xerrors.Errorf("unrecognized authorization type: %s", tokens[0])
 }
 
-func (c *controller) encodeBasicAuth(value string) (auth trivy.RegistryAuth, err error) {
+func (c *controller) decodeBasicAuth(value string) (auth trivy.RegistryAuth, err error) {
 	creds, err := base64.StdEncoding.DecodeString(value)
 	if err != nil {
 		return auth, err

--- a/pkg/store/redis/store.go
+++ b/pkg/store/redis/store.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/aquasecurity/harbor-scanner-trivy/pkg/etc"
+	"github.com/aquasecurity/harbor-scanner-trivy/pkg/model/harbor"
 	"github.com/aquasecurity/harbor-scanner-trivy/pkg/model/job"
 	"github.com/aquasecurity/harbor-scanner-trivy/pkg/store"
 	"github.com/gomodule/redigo/redis"
@@ -139,7 +140,7 @@ func (rs *redisStore) UpdateStatus(scanJobID string, newStatus job.ScanJobStatus
 	return rs.SaveScanJob(*scanJob)
 }
 
-func (rs *redisStore) UpdateReports(scanJobID string, reports job.ScanReports) error {
+func (rs *redisStore) UpdateReport(scanJobID string, report harbor.ScanReport) error {
 	log.WithFields(log.Fields{
 		"scan_job_id": scanJobID,
 	}).Debug("Updating reports for scan job")
@@ -149,7 +150,7 @@ func (rs *redisStore) UpdateReports(scanJobID string, reports job.ScanReports) e
 		return err
 	}
 
-	scanJob.Reports = reports
+	scanJob.Report = report
 	return rs.SaveScanJob(*scanJob)
 }
 

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"github.com/aquasecurity/harbor-scanner-trivy/pkg/model/harbor"
 	"github.com/aquasecurity/harbor-scanner-trivy/pkg/model/job"
 )
 
@@ -8,5 +9,5 @@ type DataStore interface {
 	SaveScanJob(scanJob job.ScanJob) error
 	GetScanJob(scanJobID string) (*job.ScanJob, error)
 	UpdateStatus(scanJobID string, newStatus job.ScanJobStatus, error ...string) error
-	UpdateReports(scanJobID string, reports job.ScanReports) error
+	UpdateReport(scanJobID string, reports harbor.ScanReport) error
 }

--- a/test/component/client_test.go
+++ b/test/component/client_test.go
@@ -54,7 +54,7 @@ func (c *Client) RequestScan(request harbor.ScanRequest) (scanResp harbor.ScanRe
 }
 
 // GetScanReport polls for ScanReport associated with the given ScanRequest ID.
-func (c *Client) GetScanReport(scanRequestID string) (report harbor.ScanResult, err error) {
+func (c *Client) GetScanReport(scanRequestID string) (report harbor.ScanReport, err error) {
 	res, err := c.doGetScanReport(scanRequestID)
 	for err == nil && res.StatusCode == http.StatusFound {
 		time.Sleep(10 * time.Second)

--- a/test/integration/api/rest_api_test.go
+++ b/test/integration/api/rest_api_test.go
@@ -76,30 +76,28 @@ func TestRestApi(t *testing.T) {
 		store.On("GetScanJob", "job:123").Return(&job.ScanJob{
 			ID:     "job:123",
 			Status: job.Finished,
-			Reports: job.ScanReports{
-				HarborScanReport: harbor.ScanResult{
-					GeneratedAt: now,
-					Artifact: harbor.Artifact{
-						Repository: "library/mongo",
-						Digest:     "sha256:6c3c624b58dbbcd3c0dd82b4c53f04194d1247c6eebdaab7c610cf7d66709b3b",
-					},
-					Scanner: harbor.Scanner{
-						Name:    "Trivy",
-						Vendor:  "Aqua Security",
-						Version: "0.1.6",
-					},
-					Severity: harbor.SevCritical,
-					Vulnerabilities: []harbor.VulnerabilityItem{
-						{
-							ID:          "CVE-2019-1111",
-							Pkg:         "openssl",
-							Version:     "2.0-rc1",
-							FixVersion:  "2.1",
-							Severity:    harbor.SevCritical,
-							Description: "You'd better upgrade your server",
-							Links: []string{
-								"http://cve.com?id=CVE-2019-1111",
-							},
+			Report: harbor.ScanReport{
+				GeneratedAt: now,
+				Artifact: harbor.Artifact{
+					Repository: "library/mongo",
+					Digest:     "sha256:6c3c624b58dbbcd3c0dd82b4c53f04194d1247c6eebdaab7c610cf7d66709b3b",
+				},
+				Scanner: harbor.Scanner{
+					Name:    "Trivy",
+					Vendor:  "Aqua Security",
+					Version: "0.1.6",
+				},
+				Severity: harbor.SevCritical,
+				Vulnerabilities: []harbor.VulnerabilityItem{
+					{
+						ID:          "CVE-2019-1111",
+						Pkg:         "openssl",
+						Version:     "2.0-rc1",
+						FixVersion:  "2.1",
+						Severity:    harbor.SevCritical,
+						Description: "You'd better upgrade your server",
+						Links: []string{
+							"http://cve.com?id=CVE-2019-1111",
 						},
 					},
 				},

--- a/test/integration/store/redis_store_test.go
+++ b/test/integration/store/redis_store_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aquasecurity/harbor-scanner-trivy/pkg/etc"
 	"github.com/aquasecurity/harbor-scanner-trivy/pkg/model/harbor"
 	"github.com/aquasecurity/harbor-scanner-trivy/pkg/model/job"
-	"github.com/aquasecurity/harbor-scanner-trivy/pkg/model/trivy"
 	"github.com/aquasecurity/harbor-scanner-trivy/pkg/store/redis"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -72,31 +71,22 @@ func TestRedisStore(t *testing.T) {
 			Status: job.Pending,
 		}, j)
 
-		scanReports := job.ScanReports{
-			HarborScanReport: harbor.ScanResult{
-				Severity: harbor.SevHigh,
-				Vulnerabilities: []harbor.VulnerabilityItem{
-					{
-						ID: "CVE-2013-1400",
-					},
-				},
-			},
-			TrivyScanReport: trivy.ScanResult{
-				Vulnerabilities: []trivy.Vulnerability{
-					{
-						VulnerabilityID: "CVE-2013-1400",
-					},
+		scanReport := harbor.ScanReport{
+			Severity: harbor.SevHigh,
+			Vulnerabilities: []harbor.VulnerabilityItem{
+				{
+					ID: "CVE-2013-1400",
 				},
 			},
 		}
 
-		err = dataStore.UpdateReports(scanJobID, scanReports)
+		err = dataStore.UpdateReport(scanJobID, scanReport)
 		require.NoError(t, err, "updating scan job reports should not fail")
 
 		j, err = dataStore.GetScanJob(scanJobID)
 		require.NoError(t, err, "retrieving scan job should not fail")
 		require.NotNil(t, j, "retrieved scan job must not be nil")
-		assert.Equal(t, scanReports, j.Reports)
+		assert.Equal(t, scanReport, j.Report)
 
 		err = dataStore.UpdateStatus(scanJobID, job.Finished)
 		require.NoError(t, err)


### PR DESCRIPTION
I've added unit tests to the main flows in scanning controller.

Also I stopped persisting Trivy scan report in Redis which was redundant.