### PR TITLE
Added .DS_Store and thumbs.db to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ scanner-trivy
 dist/
 
 coverage.txt
+
+# Directory Cache Files
+.DS_Store
+thumbs.db
+


### PR DESCRIPTION
## Description

`.DS_Store` is a MacOS directory cache file and `thumbs.db` is a windows directory cache file. Sometimes Mac/Windows users accidentally push these files which may interfere with other Mac/Windows users.