### PR TITLE
chore: Bump up Trivy from 0.1.6 to 0.1.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # That's the only place where you're supposed to specify or change version of Trivy.
-ARG TRIVY_VERSION=0.1.6
+ARG TRIVY_VERSION=0.1.7
 
 FROM aquasec/trivy:${TRIVY_VERSION}
 
@@ -7,9 +7,6 @@ FROM aquasec/trivy:${TRIVY_VERSION}
 # instruction after a FROM. To use the default value of an ARG declared before the first
 # FROM use an ARG instruction without a value inside of a build stage.
 ARG TRIVY_VERSION
-
-# Trivy aquasec/trivy:0.1.6 does not have rpm preinstalled.
-RUN apk update && apk add --no-cache rpm
 
 COPY scanner-trivy /app/scanner-trivy
 

--- a/README.md
+++ b/README.md
@@ -64,14 +64,14 @@ make container
       $ openssl genrsa -out tls.key 2048
       $ openssl req -new -x509 \
         -key tls.key \
-        -out tls.cert \
+        -out tls.crt \
         -days 365 \
         -subj /CN=harbor-scanner-trivy
       ```
    2. Create a `tls` secret from the two generated files:
       ```
       $ kubectl create secret tls harbor-scanner-trivy-tls \
-        --cert=tls.cert \
+        --cert=tls.crt \
         --key=tls.key
       ```
 3. Create deployment and service for the scanner adapter:
@@ -86,9 +86,10 @@ make container
 5. Update deployment's image to `aquasec/harbor-scanner-trivy:dev`.
    ```
    $ kubectl set image deployment harbor-scanner-trivy \
+     init=aquasec/harbor-scanner-trivy:dev
+   $ kubectl set image deployment harbor-scanner-trivy \
      main=aquasec/harbor-scanner-trivy:dev
    ```
-
 
 ## Testing
 


### PR DESCRIPTION
If you want to test it, try running component tests with the default alpine:3.10.2. Instructions are in README.
Then change the image to Amazon or Distroless, e.g. gcr.io/distroless/java, and run the component test again.