### PR TITLE
chore: Bump up Trivy to 0.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # That's the only place where you're supposed to specify or change version of Trivy.
-ARG TRIVY_VERSION=0.1.7
+ARG TRIVY_VERSION=0.2.0
 
 FROM aquasec/trivy:${TRIVY_VERSION}
 

--- a/README.md
+++ b/README.md
@@ -87,10 +87,9 @@ make container
    ```
    $ make container
    ```
-6. Update StatefulSet's images to `aquasec/harbor-scanner-trivy:dev`
+6. Update StatefulSet's image to `aquasec/harbor-scanner-trivy:dev`
    ```
    $ kubectl set image sts harbor-scanner-trivy \
-     init=aquasec/harbor-scanner-trivy:dev \
      main=aquasec/harbor-scanner-trivy:dev
    ```
 7. Scale up the StatefulSet:

--- a/kube/harbor-scanner-trivy.yaml
+++ b/kube/harbor-scanner-trivy.yaml
@@ -38,28 +38,6 @@ spec:
       labels:
         app: harbor-scanner-trivy
     spec:
-      initContainers:
-        - name: init
-          image: aquasec/harbor-scanner-trivy:0.1.0-rc1
-          imagePullPolicy: IfNotPresent
-          command:
-            - "trivy"
-            - "--debug"
-            - "--no-progress"
-            - "--cache-dir=/root/.cache/trivy"
-            - "--refresh"
-          volumeMounts:
-            - mountPath: /root/.cache
-              name: data
-          resources:
-            requests:
-              cpu: 200m
-              memory: 1500Mi
-            limits:
-              cpu: 1
-              memory: 2Gi
-          securityContext:
-            readOnlyRootFilesystem: false
       containers:
         - name: main
           image: aquasec/harbor-scanner-trivy:0.1.0-rc1


### PR DESCRIPTION
We can benefit from the prebuilt DB used by Trivy now. No need to use initContainer anymore. The initial scan is fast anyway.