### PR TITLE
chore: bump up Trivy from 0.2.0 to 0.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # That's the only place where you're supposed to specify or change version of Trivy.
-ARG TRIVY_VERSION=0.2.0
+ARG TRIVY_VERSION=0.2.1
 
 FROM aquasec/trivy:${TRIVY_VERSION}
 


### PR DESCRIPTION
Update to the last Trivy version  