### PR TITLE
Fix CIS Docker Benchmark warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,7 @@ COPY scanner-trivy /app/scanner-trivy
 
 ENV TRIVY_VERSION=${TRIVY_VERSION}
 
+RUN adduser -H -D -h /app -s /bin/sh -u 1000 scanner-trivy
+USER scanner-trivy
+
 ENTRYPOINT ["/app/scanner-trivy"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,13 @@ COPY scanner-trivy /app/scanner-trivy
 
 ENV TRIVY_VERSION=${TRIVY_VERSION}
 
+RUN apk add --no-cache curl
+
 RUN adduser -H -D -h /app -s /bin/sh -u 1000 scanner-trivy
 USER scanner-trivy
+
+ENV SCANNER_API_SERVER_ADDR=":8080"
+HEALTHCHECK --interval=10s \
+  CMD curl --fail http://localhost${SCANNER_API_SERVER_ADDR}/probe/healthy || exit 1
 
 ENTRYPOINT ["/app/scanner-trivy"]


### PR DESCRIPTION
Fix CIS Docker Benchmark warnings
- 4.1 Ensure a user for the container has been created
- 4.6 Ensure HEALTHCHECK instructions have been added to the container image

Related to #27 

---
After corrections an analyse with docker/docker-bench-security returns :
```
[INFO] 4 - Container Images and Build File                                                                                                                                                                                                                                         
[PASS] 4.1  - Ensure a user for the container has been created                                                                                                                                                                                                                     
[NOTE] 4.2  - Ensure that containers use trusted base images                                                                                                                                                                                                                       
[NOTE] 4.3  - Ensure unnecessary packages are not installed in the container                                                                                                                                                                                                       
[NOTE] 4.4  - Ensure images are scanned and rebuilt to include security patches                                                                                                                                                                                                    
[WARN] 4.5  - Ensure Content trust for Docker is Enabled                                                                                                                                                                                                                           
[PASS] 4.6  - Ensure HEALTHCHECK instructions have been added to the container image                                                                                                                                                                                               
[PASS] 4.7  - Ensure update instructions are not use alone in the Dockerfile
[NOTE] 4.8  - Ensure setuid and setgid permissions are removed in the images
[INFO] 4.9  - Ensure COPY is used instead of ADD in Dockerfile
[INFO]      * ADD in image history: [sku/harbor-scanner-trivy:dev]
[NOTE] 4.10  - Ensure secrets are not stored in Dockerfiles
[NOTE] 4.11  - Ensure verified packages are only Installed
```