### PR TITLE
Helm fixes

### DIFF
--- a/helm/harbor-scanner-trivy/Chart.yaml
+++ b/helm/harbor-scanner-trivy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: harbor-scanner-trivy
-version: 0.1.2
+version: 0.1.3
 appVersion: "0.2.1"
 description: Trivy as a plug-in vulnerability scanner in the Harbor registry
 keywords:

--- a/helm/harbor-scanner-trivy/templates/statefulset.yaml
+++ b/helm/harbor-scanner-trivy/templates/statefulset.yaml
@@ -112,14 +112,12 @@ spec:
             successThreshold: 1
             failureThreshold: 3
           volumeMounts:
-            {{- if .Values.persistence.enabled }}
             - mountPath: /tmp
               name: tmp-data
               readOnly: false
             - mountPath: /home/scanner/.cache
               name: data
               readOnly: false
-            {{- end }}
             {{- if .Values.scanner.api.tlsEnabled }}
             - mountPath: /certs
               name: certs
@@ -130,8 +128,10 @@ spec:
 {{ toYaml .Values.resources | indent 12 }}
           {{- end }}
       volumes:
-        {{- if .Values.persistence.enabled }}
         - name: tmp-data
+          emptyDir: {}
+        {{- if not .Values.persistence.enabled }}
+        - name: data
           emptyDir: {}
         {{- end }}
         {{- if .Values.scanner.api.tlsEnabled }}

--- a/helm/harbor-scanner-trivy/templates/statefulset.yaml
+++ b/helm/harbor-scanner-trivy/templates/statefulset.yaml
@@ -29,15 +29,18 @@ spec:
         app.kubernetes.io/name: {{ include "harbor-scanner-trivy.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      {{- if .Values.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.podSecurityContext | indent 8 }}
+      {{- end }}
       containers:
         - name: main
           image: {{ template "harbor-scanner-trivy.imageRef" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+          {{- if .Values.securityContext }}
           securityContext:
-            privileged: false
-            runAsUser: 1000
-            runAsNonRoot: true
-            readOnlyRootFilesystem: true
+{{ toYaml .Values.securityContext | indent 12 }}
+          {{- end }}
           env:
             - name: "SCANNER_LOG_LEVEL"
               value: {{ .Values.scanner.logLevel | quote }}

--- a/helm/harbor-scanner-trivy/values.yaml
+++ b/helm/harbor-scanner-trivy/values.yaml
@@ -11,7 +11,7 @@ replicaCount: 1
 
 persistence:
   enabled: true
-  storageClass: "standard"
+  storageClass: ""
   accessMode: ReadWriteOnce
   size: 5Gi
 

--- a/helm/harbor-scanner-trivy/values.yaml
+++ b/helm/harbor-scanner-trivy/values.yaml
@@ -23,6 +23,15 @@ resources:
     cpu: 1
     memory: 1Gi
 
+podSecurityContext:
+  runAsUser: 1000
+  runAsNonRoot: true
+  fsGroup: 1000
+
+securityContext:
+  privileged: false
+  readOnlyRootFilesystem: true
+
 scanner:
   logLevel: info
   api:


### PR DESCRIPTION
Issue: https://github.com/aquasecurity/harbor-scanner-trivy/issues/69

Some fixes for the Helm chart:
- Add fsGroup and move the securityContext to podTemplateSpec (as it doesn't support fsGroup on container level). This fixes the .cache directory not being writable
- Use emptyDir for the data volume when persistency is disabled, as otherwise it's on the root filesystem which is mounted read-only due to the readOnlyRootFilesystem security context option
- Always create and mount the tmp-data emptyDir volume, this makes it possible to run without persistent volumes (emptyDir isn't persistent)
- By default, use the default storage class of the cluster

The fixes for running without persistent volumes are mainly useful for testing