### PR TITLE
feat: Add support for scanning images from insecure registry

### DIFF
--- a/pkg/mock/wrapper.go
+++ b/pkg/mock/wrapper.go
@@ -13,7 +13,7 @@ func NewWrapper() *Wrapper {
 	return &Wrapper{}
 }
 
-func (w *Wrapper) Run(imageRef string, auth trivy.RegistryAuth) (trivy.ScanReport, error) {
-	args := w.Called(imageRef, auth)
+func (w *Wrapper) Run(imageRef string, auth trivy.RegistryAuth, insecureRegistry bool) (trivy.ScanReport, error) {
+	args := w.Called(imageRef, auth, insecureRegistry)
 	return args.Get(0).(trivy.ScanReport), args.Error(1)
 }

--- a/pkg/model/harbor/model.go
+++ b/pkg/model/harbor/model.go
@@ -79,12 +79,14 @@ type ScanRequest struct {
 
 // GetImageRef returns Docker image reference for this ScanRequest.
 // Example: core.harbor.domain/scanners/mysql@sha256:3b00a364fb74246ca119d16111eb62f7302b2ff66d51e373c2bb209f8a1f3b9e
-func (c ScanRequest) GetImageRef() (string, error) {
+func (c ScanRequest) GetImageRef() (imageRef string, insecureRegistry bool, err error) {
 	registryURL, err := url.Parse(c.Registry.URL)
 	if err != nil {
-		return "", xerrors.Errorf("parsing registry URL: %w", err)
+		return imageRef, insecureRegistry, xerrors.Errorf("parsing registry URL: %w", err)
 	}
-	return fmt.Sprintf("%s/%s@%s", registryURL.Host, c.Artifact.Repository, c.Artifact.Digest), nil
+	imageRef = fmt.Sprintf("%s/%s@%s", registryURL.Host, c.Artifact.Repository, c.Artifact.Digest)
+	insecureRegistry = "http" == registryURL.Scheme
+	return
 }
 
 type ScanResponse struct {

--- a/pkg/scan/controller.go
+++ b/pkg/scan/controller.go
@@ -53,7 +53,7 @@ func (c *controller) scan(scanJobID string, req harbor.ScanRequest) (err error) 
 		return xerrors.Errorf("updating scan job status: %v", err)
 	}
 
-	imageRef, err := req.GetImageRef()
+	imageRef, insecureRegistry, err := req.GetImageRef()
 	if err != nil {
 		return err
 	}
@@ -63,7 +63,7 @@ func (c *controller) scan(scanJobID string, req harbor.ScanRequest) (err error) 
 		return err
 	}
 
-	scanReport, err := c.wrapper.Run(imageRef, auth)
+	scanReport, err := c.wrapper.Run(imageRef, auth, insecureRegistry)
 	if err != nil {
 		return xerrors.Errorf("running trivy wrapper: %v", err)
 	}

--- a/pkg/scan/controller_test.go
+++ b/pkg/scan/controller_test.go
@@ -62,6 +62,7 @@ func TestController_Scan(t *testing.T) {
 				Args: []interface{}{
 					"core.harbor.domain/library/mongo@sha256:917f5b7f4bef1b35ee90f03033f33a81002511c1e0767fd44276d4bd9cd2fa8e",
 					trivy.RegistryAuth{Username: "user", Password: "password"},
+					false,
 				},
 				ReturnArgs: []interface{}{
 					trivyReport,
@@ -106,6 +107,7 @@ func TestController_Scan(t *testing.T) {
 				Args: []interface{}{
 					"core.harbor.domain/library/mongo@sha256:917f5b7f4bef1b35ee90f03033f33a81002511c1e0767fd44276d4bd9cd2fa8e",
 					trivy.RegistryAuth{Username: "user", Password: "password"},
+					false,
 				},
 				ReturnArgs: []interface{}{
 					trivy.ScanReport{},

--- a/pkg/trivy/wrapper.go
+++ b/pkg/trivy/wrapper.go
@@ -20,7 +20,7 @@ type RegistryAuth struct {
 }
 
 type Wrapper interface {
-	Run(imageRef string, auth RegistryAuth) (ScanReport, error)
+	Run(imageRef string, auth RegistryAuth, insecureRegistry bool) (ScanReport, error)
 }
 
 type wrapper struct {
@@ -33,7 +33,7 @@ func NewWrapper(config etc.Trivy) Wrapper {
 	}
 }
 
-func (w *wrapper) Run(imageRef string, auth RegistryAuth) (report ScanReport, err error) {
+func (w *wrapper) Run(imageRef string, auth RegistryAuth, insecureRegistry bool) (report ScanReport, err error) {
 	log.WithField("image_ref", imageRef).Debug("Started scanning")
 
 	executable, err := exec.LookPath("trivy")
@@ -81,6 +81,9 @@ func (w *wrapper) Run(imageRef string, auth RegistryAuth) (report ScanReport, er
 		cmd.Env = append(cmd.Env,
 			fmt.Sprintf("TRIVY_USERNAME=%s", auth.Username),
 			fmt.Sprintf("TRIVY_PASSWORD=%s", auth.Password))
+	}
+	if insecureRegistry {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("TRIVY_NON_SSL=true"))
 	}
 
 	stderrBuffer := bytes.Buffer{}


### PR DESCRIPTION
When people evaluate Harbor they usually do not setup TLS. This means that the scanner adapter receives scan requests with insecure registry URLs , e.g. http://core:8080. If we build the imageRef from such URL Trivy fails, because it's trying to append the https:// before fetching layers.

The solution is to set the `TRIVY_NON_SSL` env for insecure registry URLs.