### PR TITLE
Include layer ID in Vulnerabilities information

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # That's the only place where you're supposed to specify or change version of Trivy.
-ARG TRIVY_VERSION=0.5.0
+ARG TRIVY_VERSION=0.5.1
 
 FROM aquasec/trivy:${TRIVY_VERSION}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # That's the only place where you're supposed to specify or change version of Trivy.
-ARG TRIVY_VERSION=0.4.3
+ARG TRIVY_VERSION=0.5.0
 
 FROM aquasec/trivy:${TRIVY_VERSION}
 

--- a/helm/harbor-scanner-trivy/Chart.yaml
+++ b/helm/harbor-scanner-trivy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: harbor-scanner-trivy
-version: 0.1.5
-appVersion: "0.2.3"
+version: 0.1.6
+appVersion: "0.3.0"
 description: Trivy as a plug-in vulnerability scanner in the Harbor registry
 keywords:
   - scanner

--- a/helm/harbor-scanner-trivy/values.yaml
+++ b/helm/harbor-scanner-trivy/values.yaml
@@ -4,7 +4,7 @@ fullnameOverride: ""
 image:
   registry: docker.io
   repository: aquasec/harbor-scanner-trivy
-  tag: 0.2.3
+  tag: 0.3.0
   pullPolicy: IfNotPresent
 
 replicaCount: 1

--- a/pkg/http/api/v1/handler_test.go
+++ b/pkg/http/api/v1/handler_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/aquasecurity/harbor-scanner-trivy/pkg/etc"
+	"github.com/opencontainers/go-digest"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -321,6 +322,7 @@ func TestRequestHandler_GetScanReport(t *testing.T) {
 								Links: []string{
 									"http://cve.com?id=CVE-2019-1111",
 								},
+								LayerID: digest.Digest("sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10"),
 							},
 						},
 					},
@@ -350,7 +352,8 @@ func TestRequestHandler_GetScanReport(t *testing.T) {
       "description": "You'd better upgrade your server",
       "links": [
         "http://cve.com?id=CVE-2019-1111"
-      ]
+      ],
+      "layerID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10"
     }
   ]
 }`, now.Format(time.RFC3339Nano)),

--- a/pkg/http/api/v1/handler_test.go
+++ b/pkg/http/api/v1/handler_test.go
@@ -352,7 +352,7 @@ func TestRequestHandler_GetScanReport(t *testing.T) {
       "links": [
         "http://cve.com?id=CVE-2019-1111"
       ],
-      "layerID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10"
+      "layer_id": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10"
     }
   ]
 }`, now.Format(time.RFC3339Nano)),

--- a/pkg/http/api/v1/handler_test.go
+++ b/pkg/http/api/v1/handler_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/aquasecurity/harbor-scanner-trivy/pkg/etc"
-	"github.com/opencontainers/go-digest"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -322,7 +321,7 @@ func TestRequestHandler_GetScanReport(t *testing.T) {
 								Links: []string{
 									"http://cve.com?id=CVE-2019-1111",
 								},
-								LayerID: digest.Digest("sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10"),
+								LayerID: "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
 							},
 						},
 					},

--- a/pkg/model/harbor/model.go
+++ b/pkg/model/harbor/model.go
@@ -7,6 +7,8 @@ import (
 	"golang.org/x/xerrors"
 	"net/url"
 	"time"
+
+	"github.com/opencontainers/go-digest"
 )
 
 // Severity represents the severity of a image/component in terms of vulnerability.
@@ -103,13 +105,14 @@ type ScanReport struct {
 
 // VulnerabilityItem is an item in the vulnerability result returned by vulnerability details API.
 type VulnerabilityItem struct {
-	ID          string   `json:"id"`
-	Pkg         string   `json:"package"`
-	Version     string   `json:"version"`
-	FixVersion  string   `json:"fix_version,omitempty"`
-	Severity    Severity `json:"severity"`
-	Description string   `json:"description"`
-	Links       []string `json:"links"`
+	ID          string        `json:"id"`
+	Pkg         string        `json:"package"`
+	Version     string        `json:"version"`
+	FixVersion  string        `json:"fix_version,omitempty"`
+	Severity    Severity      `json:"severity"`
+	Description string        `json:"description"`
+	Links       []string      `json:"links"`
+	LayerID     digest.Digest `json:"layerID"`
 }
 
 type ScannerAdapterMetadata struct {

--- a/pkg/model/harbor/model.go
+++ b/pkg/model/harbor/model.go
@@ -7,8 +7,6 @@ import (
 	"golang.org/x/xerrors"
 	"net/url"
 	"time"
-
-	"github.com/opencontainers/go-digest"
 )
 
 // Severity represents the severity of a image/component in terms of vulnerability.
@@ -105,14 +103,14 @@ type ScanReport struct {
 
 // VulnerabilityItem is an item in the vulnerability result returned by vulnerability details API.
 type VulnerabilityItem struct {
-	ID          string        `json:"id"`
-	Pkg         string        `json:"package"`
-	Version     string        `json:"version"`
-	FixVersion  string        `json:"fix_version,omitempty"`
-	Severity    Severity      `json:"severity"`
-	Description string        `json:"description"`
-	Links       []string      `json:"links"`
-	LayerID     digest.Digest `json:"layerID"`
+	ID          string   `json:"id"`
+	Pkg         string   `json:"package"`
+	Version     string   `json:"version"`
+	FixVersion  string   `json:"fix_version,omitempty"`
+	Severity    Severity `json:"severity"`
+	Description string   `json:"description"`
+	Links       []string `json:"links"`
+	LayerID     string   `json:"layer_id"`
 }
 
 type ScannerAdapterMetadata struct {

--- a/pkg/scan/transformer.go
+++ b/pkg/scan/transformer.go
@@ -38,7 +38,7 @@ func NewTransformer(clock Clock) Transformer {
 	}
 }
 
-func (t *transformer) Transform(artifact harbor.Artifact, source trivy.ScanReport) (harbor.ScanReport) {
+func (t *transformer) Transform(artifact harbor.Artifact, source trivy.ScanReport) harbor.ScanReport {
 	vulnerabilities := make([]harbor.VulnerabilityItem, len(source.Vulnerabilities))
 
 	for i, v := range source.Vulnerabilities {

--- a/pkg/scan/transformer_test.go
+++ b/pkg/scan/transformer_test.go
@@ -39,6 +39,7 @@ func TestTransformer_Transform(t *testing.T) {
 					"http://cve.com?id=CVE-0000-0001",
 					"http://vendor.com?id=CVE-0000-0001",
 				},
+				LayerID:          "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
 			},
 			{
 				VulnerabilityID:  "CVE-0000-0002",
@@ -50,6 +51,7 @@ func TestTransformer_Transform(t *testing.T) {
 				References: []string{
 					"http://cve.com?id=CVE-0000-0002",
 				},
+				LayerID:          "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb11",
 			},
 			{
 				VulnerabilityID:  "CVE-0000-0003",
@@ -61,6 +63,7 @@ func TestTransformer_Transform(t *testing.T) {
 				References: []string{
 					"http://cve.com?id=CVE-0000-0003",
 				},
+				LayerID:          "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb12",
 			},
 			{
 				VulnerabilityID:  "CVE-0000-0004",
@@ -72,12 +75,14 @@ func TestTransformer_Transform(t *testing.T) {
 				References: []string{
 					"http://cve.com?id=CVE-0000-0004",
 				},
+				LayerID:          "UNKNOWN",
 			},
 			{
 				VulnerabilityID:  "CVE-0000-0005",
 				PkgName:          "PKG-05",
 				InstalledVersion: "PKG-05-VER",
 				Severity:         "~~~UNKNOWN~~~",
+				LayerID:          "",
 			},
 			{
 				VulnerabilityID:  "CVE-0000-0006",
@@ -111,6 +116,7 @@ func TestTransformer_Transform(t *testing.T) {
 					"http://cve.com?id=CVE-0000-0001",
 					"http://vendor.com?id=CVE-0000-0001",
 				},
+				LayerID:     "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
 			},
 			{
 				ID:          "CVE-0000-0002",
@@ -122,6 +128,7 @@ func TestTransformer_Transform(t *testing.T) {
 				Links: []string{
 					"http://cve.com?id=CVE-0000-0002",
 				},
+				LayerID:     "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb11",
 			},
 			{
 				ID:          "CVE-0000-0003",
@@ -133,6 +140,7 @@ func TestTransformer_Transform(t *testing.T) {
 				Links: []string{
 					"http://cve.com?id=CVE-0000-0003",
 				},
+				LayerID:     "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb12",
 			},
 			{
 				ID:          "CVE-0000-0004",
@@ -144,6 +152,7 @@ func TestTransformer_Transform(t *testing.T) {
 				Links: []string{
 					"http://cve.com?id=CVE-0000-0004",
 				},
+				LayerID:     "UNKNOWN",
 			},
 			{
 				ID:       "CVE-0000-0005",
@@ -151,6 +160,7 @@ func TestTransformer_Transform(t *testing.T) {
 				Version:  "PKG-05-VER",
 				Severity: harbor.SevUnknown,
 				Links:    []string{},
+				LayerID:  "",
 			},
 			{
 				ID:       "CVE-0000-0006",
@@ -158,6 +168,7 @@ func TestTransformer_Transform(t *testing.T) {
 				Version:  "PKG-06-VER",
 				Severity: harbor.SevUnknown,
 				Links:    []string{},
+				LayerID:  "",
 			},
 		},
 	}, hr)

--- a/pkg/trivy/model.go
+++ b/pkg/trivy/model.go
@@ -1,17 +1,20 @@
 package trivy
 
+import "github.com/opencontainers/go-digest"
+
 type ScanReport struct {
 	Target          string          `json:"Target"`
 	Vulnerabilities []Vulnerability `json:"Vulnerabilities"`
 }
 
 type Vulnerability struct {
-	VulnerabilityID  string   `json:"VulnerabilityID"`
-	PkgName          string   `json:"PkgName"`
-	InstalledVersion string   `json:"InstalledVersion"`
-	FixedVersion     string   `json:"FixedVersion"`
-	Title            string   `json:"Title"`
-	Description      string   `json:"Description"`
-	Severity         string   `json:"Severity"`
-	References       []string `json:"References"`
+	VulnerabilityID  string        `json:"VulnerabilityID"`
+	PkgName          string        `json:"PkgName"`
+	InstalledVersion string        `json:"InstalledVersion"`
+	FixedVersion     string        `json:"FixedVersion"`
+	Title            string        `json:"Title"`
+	Description      string        `json:"Description"`
+	Severity         string        `json:"Severity"`
+	References       []string      `json:"References"`
+	LayerID          digest.Digest `json:"LayerID"`
 }

--- a/pkg/trivy/model.go
+++ b/pkg/trivy/model.go
@@ -1,20 +1,18 @@
 package trivy
 
-import "github.com/opencontainers/go-digest"
-
 type ScanReport struct {
 	Target          string          `json:"Target"`
 	Vulnerabilities []Vulnerability `json:"Vulnerabilities"`
 }
 
 type Vulnerability struct {
-	VulnerabilityID  string        `json:"VulnerabilityID"`
-	PkgName          string        `json:"PkgName"`
-	InstalledVersion string        `json:"InstalledVersion"`
-	FixedVersion     string        `json:"FixedVersion"`
-	Title            string        `json:"Title"`
-	Description      string        `json:"Description"`
-	Severity         string        `json:"Severity"`
-	References       []string      `json:"References"`
-	LayerID          digest.Digest `json:"LayerID"`
+	VulnerabilityID  string   `json:"VulnerabilityID"`
+	PkgName          string   `json:"PkgName"`
+	InstalledVersion string   `json:"InstalledVersion"`
+	FixedVersion     string   `json:"FixedVersion"`
+	Title            string   `json:"Title"`
+	Description      string   `json:"Description"`
+	Severity         string   `json:"Severity"`
+	References       []string `json:"References"`
+	LayerID          string   `json:"LayerID"`
 }

--- a/pkg/trivy/wrapper.go
+++ b/pkg/trivy/wrapper.go
@@ -125,7 +125,7 @@ func (w *wrapper) parseScanReports(reportFile io.Reader) (report ScanReport, err
 
 	// Collect all vulnerabilities to single scanReport to allow showing those in Harbor
 	report.Target = scanReports[0].Target
-	report.Vulnerabilities = []Vulnerability{}
+	report.Vulnerabilities = make([]Vulnerability, 0, len(scanReports[0].Vulnerabilities))
 	for _, scanReport := range scanReports {
 		log.WithField("target", scanReport.Target).Trace("Parsing vulnerabilities")
 		report.Vulnerabilities = append(report.Vulnerabilities, scanReport.Vulnerabilities...)

--- a/pkg/trivy/wrapper_test.go
+++ b/pkg/trivy/wrapper_test.go
@@ -20,7 +20,8 @@ const (
 		"Severity": "MEDIUM",
 		"References": [
 			"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-6543"
-		]
+		],
+		"LayerID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10"
 	}]
 },
 {
@@ -34,7 +35,8 @@ const (
 		"References": [
 			"http://packetstormsecurity.com/files/152787/dotCMS-5.1.1-Vulnerable-Dependencies.html",
 			"http://packetstormsecurity.com/files/153237/RetireJS-CORS-Issue-Script-Execution.html"
-		]
+		],
+		"LayerID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10"
 	}]
 },
 {
@@ -47,7 +49,8 @@ const (
 		"Severity": "MEDIUM",
 		"References": [
 			"http://linux.oracle.com/cve/CVE-2016-5385.html"
-		]
+		],
+		"LayerID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb11"
 	}]
 },
 {
@@ -79,6 +82,7 @@ func TestWrapperParseScanReports(t *testing.T) {
 						References: []string{
 							"https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-6543",
 						},
+						LayerID: "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
 					},
 					{
 						VulnerabilityID:  "CVE-2019-11358",
@@ -90,6 +94,7 @@ func TestWrapperParseScanReports(t *testing.T) {
 							"http://packetstormsecurity.com/files/152787/dotCMS-5.1.1-Vulnerable-Dependencies.html",
 							"http://packetstormsecurity.com/files/153237/RetireJS-CORS-Issue-Script-Execution.html",
 						},
+						LayerID: "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
 					},
 					{
 						VulnerabilityID:  "CVE-2016-5385",
@@ -100,6 +105,7 @@ func TestWrapperParseScanReports(t *testing.T) {
 						References: []string{
 							"http://linux.oracle.com/cve/CVE-2016-5385.html",
 						},
+						LayerID: "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb11",
 					},
 				},
 			},

--- a/test/component/component_test.go
+++ b/test/component/component_test.go
@@ -86,7 +86,7 @@ func TestComponent(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, req.Artifact, report.Artifact)
-	assert.Equal(t, harbor.Scanner{Name: "Trivy", Vendor: "Aqua Security", Version: "0.5.0"}, report.Scanner)
+	assert.Equal(t, harbor.Scanner{Name: "Trivy", Vendor: "Aqua Security", Version: "0.5.1"}, report.Scanner)
 	// TODO Adding asserts on CVEs is tricky as we do not have any control over upstream vulnerabilities database used by Trivy.
 	for _, v := range report.Vulnerabilities {
 		t.Logf("ID %s, Package: %s, Version: %s, Severity: %s", v.ID, v.Pkg, v.Version, v.Severity)

--- a/test/component/component_test.go
+++ b/test/component/component_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/caarlos0/env/v6"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
-	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
@@ -86,7 +85,7 @@ func TestComponent(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, req.Artifact, report.Artifact)
-	assert.Equal(t, harbor.Scanner{Name: "Trivy", Vendor: "Aqua Security", Version: "0.4.3"}, report.Scanner)
+	assert.Equal(t, harbor.Scanner{Name: "Trivy", Vendor: "Aqua Security", Version: "0.5.0"}, report.Scanner)
 	// TODO Adding asserts on CVEs is tricky as we do not have any control over upstream vulnerabilities database used by Trivy.
 	for _, v := range report.Vulnerabilities {
 		t.Logf("ID %s, Package: %s, Version: %s, Severity: %s", v.ID, v.Pkg, v.Version, v.Severity)

--- a/test/component/component_test.go
+++ b/test/component/component_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/caarlos0/env/v6"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
+	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"

--- a/test/integration/api/rest_api_test.go
+++ b/test/integration/api/rest_api_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aquasecurity/harbor-scanner-trivy/pkg/mock"
 	"github.com/aquasecurity/harbor-scanner-trivy/pkg/model/harbor"
 	"github.com/aquasecurity/harbor-scanner-trivy/pkg/model/job"
-	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"io/ioutil"
@@ -101,7 +100,7 @@ func TestRestApi(t *testing.T) {
 						Links: []string{
 							"http://cve.com?id=CVE-2019-1111",
 						},
-						LayerID: digest.Digest("sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10"),
+						LayerID: "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
 					},
 				},
 			},

--- a/test/integration/api/rest_api_test.go
+++ b/test/integration/api/rest_api_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aquasecurity/harbor-scanner-trivy/pkg/mock"
 	"github.com/aquasecurity/harbor-scanner-trivy/pkg/model/harbor"
 	"github.com/aquasecurity/harbor-scanner-trivy/pkg/model/job"
+	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"io/ioutil"
@@ -100,6 +101,7 @@ func TestRestApi(t *testing.T) {
 						Links: []string{
 							"http://cve.com?id=CVE-2019-1111",
 						},
+						LayerID: digest.Digest("sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10"),
 					},
 				},
 			},
@@ -138,7 +140,8 @@ func TestRestApi(t *testing.T) {
       "description": "You'd better upgrade your server",
       "links": [
         "http://cve.com?id=CVE-2019-1111"
-      ]
+      ],
+      "layerID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10"
     }
   ]
 }`, now.Format(time.RFC3339Nano)), string(bodyBytes))

--- a/test/integration/api/rest_api_test.go
+++ b/test/integration/api/rest_api_test.go
@@ -140,7 +140,7 @@ func TestRestApi(t *testing.T) {
       "links": [
         "http://cve.com?id=CVE-2019-1111"
       ],
-      "layerID": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10"
+      "layer_id": "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10"
     }
   ]
 }`, now.Format(time.RFC3339Nano)), string(bodyBytes))


### PR DESCRIPTION
In this PR:
1. Bump Trivy version in Dockerfile (from 0.4.3 to 0.5.0)
2. Bump Harbor-Scanner-Trivy version (from 0.2.3 to 0.3.0)
3. Add LayerID to both Trivy and Harbor-Scanner-Trivy specific structs, and map LayerIds during the transformation
4. Minor code-reformattings and optimizations.

I will include inline comments for some of the changes.