### PR TITLE
feat: Pass GITHUB_TOKEN env to Trivy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # That's the only place where you're supposed to specify or change version of Trivy.
-ARG TRIVY_VERSION=0.5.1
+ARG TRIVY_VERSION=0.5.2
 
 FROM aquasec/trivy:${TRIVY_VERSION}
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Configuration of the adapter is done via environment variables at startup.
 | `SCANNER_TRIVY_VULN_TYPE`                 | `os`                               | Comma-separated list of vulnerability types. Possible values `os` and `library`      |
 | `SCANNER_TRIVY_SEVERITY`                  | `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL` | Comma-separated list of vulnerabilities severities to be displayed                   |
 | `SCANNER_TRIVY_IGNORE_UNFIXED`            | `false`                            | The flag to display only fixed vulnerabilities                                       |
+| `SCANNER_TRIVY_GITHUB_TOKEN`              | N/A                                | GitHub token to authenticate API requests (see [rate limit][gh-rate-limit])          |
 | `SCANNER_STORE_REDIS_URL`                 | `redis://harbor-harbor-redis:6379` | Redis server URI for a redis store                                                   |
 | `SCANNER_STORE_REDIS_NAMESPACE`           | `harbor.scanner.trivy:store`       | A namespace for keys in a redis store                                                |
 | `SCANNER_STORE_REDIS_POOL_MAX_ACTIVE`     | `5`                                | The max number of connections allocated by the pool for a redis store                |
@@ -198,3 +199,4 @@ This project is licensed under the Apache 2.0 license - see the [LICENSE](LICENS
 [coc-url]: https://github.com/aquasecurity/.github/blob/master/CODE_OF_CONDUCT.md
 [fowler-testing-strategies]: https://www.martinfowler.com/articles/microservice-testing/
 [issue-38]: https://github.com/aquasecurity/harbor-scanner-trivy/issues/38
+[gh-rate-limit]: https://github.com/aquasecurity/trivy#github-rate-limiting

--- a/helm/harbor-scanner-trivy/README.md
+++ b/helm/harbor-scanner-trivy/README.md
@@ -88,6 +88,7 @@ The following table lists the configurable parameters of the scanner adapter cha
 | `scanner.trivy.vulnType`              | Comma-separated list of vulnerability types. Possible values `os` and `library` | `os`   |
 | `scanner.trivy.severity`              | Comma-separated list of vulnerabilities severities to be displayed      | `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL` |
 | `scanner.trivy.ignoreUnfixed`         | The flag to display only fixed vulnerabilities                          | `false`                            |
+| `scanner.trivy.gitHubToken`           | GitHub token to authenticate API requests                               |      |
 | `scanner.store.redisURL`              | Redis server URI for a redis store                                      | `redis://harbor-harbor-redis:6379` |
 | `scanner.store.redisNamespace`        | A namespace for keys in a redis store                                   | `harbor.scanner.trivy:store`       |
 | `scanner.store.redisMaxActive`        | The max number of connections allocated by the pool for a redis store   | `5`  |

--- a/helm/harbor-scanner-trivy/templates/secret.yaml
+++ b/helm/harbor-scanner-trivy/templates/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "harbor-scanner-trivy.fullname" . }}
+  labels:
+{{ include "harbor-scanner-trivy.labels" . | indent 4 }}
+type: Opaque
+data:
+  gitHubToken: {{ .Values.scanner.trivy.gitHubToken | b64enc | quote }}

--- a/helm/harbor-scanner-trivy/templates/statefulset.yaml
+++ b/helm/harbor-scanner-trivy/templates/statefulset.yaml
@@ -64,6 +64,11 @@ spec:
               value: {{ .Values.scanner.trivy.severity | quote }}
             - name: "SCANNER_TRIVY_IGNORE_UNFIXED"
               value: {{ .Values.scanner.trivy.ignoreUnfixed | quote }}
+            - name: "SCANNER_TRIVY_GITHUB_TOKEN"
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "harbor-scanner-trivy.fullname" . }}
+                  key: gitHubToken
             - name: "SCANNER_STORE_REDIS_URL"
               value: {{ .Values.scanner.store.redisURL | quote }}
             - name: "SCANNER_STORE_REDIS_NAMESPACE"

--- a/helm/harbor-scanner-trivy/values.yaml
+++ b/helm/harbor-scanner-trivy/values.yaml
@@ -48,6 +48,7 @@ scanner:
     vulnType: "os"
     severity: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
     ignoreUnfixed: false
+    gitHubToken: ""
   store:
     redisURL: "redis://harbor-harbor-redis:6379"
     redisNamespace: "harbor.scanner.trivy:store"

--- a/pkg/etc/config.go
+++ b/pkg/etc/config.go
@@ -28,6 +28,7 @@ type Trivy struct {
 	VulnType      string `env:"SCANNER_TRIVY_VULN_TYPE" envDefault:"os"`
 	Severity      string `env:"SCANNER_TRIVY_SEVERITY" envDefault:"UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"`
 	IgnoreUnfixed bool   `env:"SCANNER_TRIVY_IGNORE_UNFIXED" envDefault:"false"`
+	GitHubToken   string `env:"SCANNER_TRIVY_GITHUB_TOKEN"`
 }
 
 type API struct {

--- a/pkg/etc/config_test.go
+++ b/pkg/etc/config_test.go
@@ -63,10 +63,11 @@ func TestGetConfig(t *testing.T) {
 					IdleTimeout:  parseDuration(t, "60s"),
 				},
 				Trivy: Trivy{
-					CacheDir:   "/home/scanner/.cache/trivy",
-					ReportsDir: "/home/scanner/.cache/reports",
-					VulnType:   "os",
-					Severity:   "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL",
+					CacheDir:    "/home/scanner/.cache/trivy",
+					ReportsDir:  "/home/scanner/.cache/reports",
+					VulnType:    "os",
+					Severity:    "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL",
+					GitHubToken: "",
 				},
 				RedisStore: RedisStore{
 					RedisURL:      "redis://localhost:6379",
@@ -98,6 +99,7 @@ func TestGetConfig(t *testing.T) {
 				"SCANNER_TRIVY_VULN_TYPE":      "os,library",
 				"SCANNER_TRIVY_SEVERITY":       "CRITICAL",
 				"SCANNER_TRIVY_IGNORE_UNFIXED": "true",
+				"SCANNER_TRIVY_GITHUB_TOKEN":   "<GITHUB_TOKEN>",
 
 				"SCANNER_STORE_REDIS_URL":             "redis://harbor-harbor-redis:6379",
 				"SCANNER_STORE_REDIS_NAMESPACE":       "test.namespace",
@@ -119,6 +121,7 @@ func TestGetConfig(t *testing.T) {
 					VulnType:      "os,library",
 					Severity:      "CRITICAL",
 					IgnoreUnfixed: true,
+					GitHubToken:   "<GITHUB_TOKEN>",
 				},
 				RedisStore: RedisStore{
 					RedisURL:      "redis://harbor-harbor-redis:6379",

--- a/pkg/scan/transformer.go
+++ b/pkg/scan/transformer.go
@@ -71,7 +71,7 @@ func (t *transformer) toLinks(references []string) []string {
 	return references
 }
 
-var trivyToHarborSeverityMap = map[string]harbor.Severity {
+var trivyToHarborSeverityMap = map[string]harbor.Severity{
 	"CRITICAL": harbor.SevCritical,
 	"HIGH":     harbor.SevHigh,
 	"MEDIUM":   harbor.SevMedium,

--- a/pkg/scan/transformer_test.go
+++ b/pkg/scan/transformer_test.go
@@ -39,7 +39,7 @@ func TestTransformer_Transform(t *testing.T) {
 					"http://cve.com?id=CVE-0000-0001",
 					"http://vendor.com?id=CVE-0000-0001",
 				},
-				LayerID:          "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
+				LayerID: "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
 			},
 			{
 				VulnerabilityID:  "CVE-0000-0002",
@@ -51,7 +51,7 @@ func TestTransformer_Transform(t *testing.T) {
 				References: []string{
 					"http://cve.com?id=CVE-0000-0002",
 				},
-				LayerID:          "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb11",
+				LayerID: "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb11",
 			},
 			{
 				VulnerabilityID:  "CVE-0000-0003",
@@ -63,7 +63,7 @@ func TestTransformer_Transform(t *testing.T) {
 				References: []string{
 					"http://cve.com?id=CVE-0000-0003",
 				},
-				LayerID:          "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb12",
+				LayerID: "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb12",
 			},
 			{
 				VulnerabilityID:  "CVE-0000-0004",
@@ -75,7 +75,7 @@ func TestTransformer_Transform(t *testing.T) {
 				References: []string{
 					"http://cve.com?id=CVE-0000-0004",
 				},
-				LayerID:          "UNKNOWN",
+				LayerID: "UNKNOWN",
 			},
 			{
 				VulnerabilityID:  "CVE-0000-0005",
@@ -116,7 +116,7 @@ func TestTransformer_Transform(t *testing.T) {
 					"http://cve.com?id=CVE-0000-0001",
 					"http://vendor.com?id=CVE-0000-0001",
 				},
-				LayerID:     "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
+				LayerID: "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb10",
 			},
 			{
 				ID:          "CVE-0000-0002",
@@ -128,7 +128,7 @@ func TestTransformer_Transform(t *testing.T) {
 				Links: []string{
 					"http://cve.com?id=CVE-0000-0002",
 				},
-				LayerID:     "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb11",
+				LayerID: "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb11",
 			},
 			{
 				ID:          "CVE-0000-0003",
@@ -140,7 +140,7 @@ func TestTransformer_Transform(t *testing.T) {
 				Links: []string{
 					"http://cve.com?id=CVE-0000-0003",
 				},
-				LayerID:     "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb12",
+				LayerID: "sha256:5216338b40a7b96416b8b9858974bbe4acc3096ee60acbc4dfb1ee02aecceb12",
 			},
 			{
 				ID:          "CVE-0000-0004",
@@ -152,7 +152,7 @@ func TestTransformer_Transform(t *testing.T) {
 				Links: []string{
 					"http://cve.com?id=CVE-0000-0004",
 				},
-				LayerID:     "UNKNOWN",
+				LayerID: "UNKNOWN",
 			},
 			{
 				ID:       "CVE-0000-0005",

--- a/pkg/trivy/wrapper.go
+++ b/pkg/trivy/wrapper.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"strings"
 )
 
 // RegistryAuth wraps registry credentials.
@@ -83,7 +84,10 @@ func (w *wrapper) Run(imageRef string, auth RegistryAuth, insecureRegistry bool)
 			fmt.Sprintf("TRIVY_PASSWORD=%s", auth.Password))
 	}
 	if insecureRegistry {
-		cmd.Env = append(cmd.Env, fmt.Sprintf("TRIVY_NON_SSL=true"))
+		cmd.Env = append(cmd.Env, "TRIVY_NON_SSL=true")
+	}
+	if strings.TrimSpace(w.config.GitHubToken) != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("GITHUB_TOKEN=%s", w.config.GitHubToken))
 	}
 
 	stderrBuffer := bytes.Buffer{}

--- a/test/component/component_test.go
+++ b/test/component/component_test.go
@@ -86,7 +86,7 @@ func TestComponent(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, req.Artifact, report.Artifact)
-	assert.Equal(t, harbor.Scanner{Name: "Trivy", Vendor: "Aqua Security", Version: "0.5.1"}, report.Scanner)
+	assert.Equal(t, harbor.Scanner{Name: "Trivy", Vendor: "Aqua Security", Version: "0.5.2"}, report.Scanner)
 	// TODO Adding asserts on CVEs is tricky as we do not have any control over upstream vulnerabilities database used by Trivy.
 	for _, v := range report.Vulnerabilities {
 		t.Logf("ID %s, Package: %s, Version: %s, Severity: %s", v.ID, v.Pkg, v.Version, v.Severity)


### PR DESCRIPTION
The Harbor team hit the rate limit in CI/CD env after enabling Trivy as the default scanner.
I'm passing GITHUB_TOKEN to Trivy executable as an env to increase the limit.

/cc @steven-zou @heww