### PR TITLE
fix: Do not show next-update-at property in metadata when we skip DB updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Configuration of the adapter is done via environment variables at startup.
 | `SCANNER_TRIVY_CACHE_DIR`                 | `/home/scanner/.cache/trivy`       | Trivy cache directory                                                                |
 | `SCANNER_TRIVY_REPORTS_DIR`               | `/home/scanner/.cache/reports`     | Trivy reports directory                                                              |
 | `SCANNER_TRIVY_DEBUG_MODE`                | `false`                            | The flag to enable or disable Trivy debug mode                                       |
-| `SCANNER_TRIVY_VULN_TYPE`                 | `os`                               | Comma-separated list of vulnerability types. Possible values `os` and `library`      |
+| `SCANNER_TRIVY_VULN_TYPE`                 | `os,library`                       | Comma-separated list of vulnerability types. Possible values are `os` and `library`. |
 | `SCANNER_TRIVY_SEVERITY`                  | `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL` | Comma-separated list of vulnerabilities severities to be displayed                   |
 | `SCANNER_TRIVY_IGNORE_UNFIXED`            | `false`                            | The flag to display only fixed vulnerabilities                                       |
 | `SCANNER_TRIVY_SKIP_UPDATE`               | `false`                            | The flag to enable or disable [Trivy DB][trivy-db] downloads from GitHub             |

--- a/cmd/scanner-trivy/main.go
+++ b/cmd/scanner-trivy/main.go
@@ -56,7 +56,7 @@ func run(info etc.BuildInfo) error {
 
 	store := redis.NewStore(config.RedisStore)
 	enqueuer := queue.NewEnqueuer(config.JobQueue, store)
-	apiHandler := v1.NewAPIHandler(info, enqueuer, store, trivy.NewWrapper(config.Trivy, ext.DefaultAmbassador))
+	apiHandler := v1.NewAPIHandler(info, config, enqueuer, store, trivy.NewWrapper(config.Trivy, ext.DefaultAmbassador))
 	apiServer := api.NewServer(config.API, apiHandler)
 
 	shutdownComplete := make(chan struct{})

--- a/helm/harbor-scanner-trivy/README.md
+++ b/helm/harbor-scanner-trivy/README.md
@@ -81,11 +81,11 @@ The following table lists the configurable parameters of the scanner adapter cha
 | `scanner.api.tlsKey`                  | The absolute path to the x509 private key file                          |                |
 | `scanner.api.readTimeout`             | The maximum duration for reading the entire request, including the body | `15s`          |
 | `scanner.api.writeTimeout`            | The maximum duration before timing out writes of the response           | `15s`          |
-| `scanner.api.idleTimeout`             | The maximum amount of time to wait for the next request when keep-alives are enabled | `60s`     |
+| `scanner.api.idleTimeout`             | The maximum amount of time to wait for the next request when keep-alives are enabled | `60s` |
 | `scanner.trivy.cacheDir`              | Trivy cache directory                                                   | `/home/scanner/.cache/trivy`   |
 | `scanner.trivy.reportsDir`            | Trivy reports directory                                                 | `/home/scanner/.cache/reports` |
-| `scanner.trivy.debugMode`             | The flag to enable or disable Trivy debug mode                          | `false`        |
-| `scanner.trivy.vulnType`              | Comma-separated list of vulnerability types. Possible values `os` and `library` | `os`   |
+| `scanner.trivy.debugMode`             | The flag to enable or disable Trivy debug mode                          | `false` |
+| `scanner.trivy.vulnType`              | Comma-separated list of vulnerability types. Possible values are `os` and `library`. | `os,library` |
 | `scanner.trivy.severity`              | Comma-separated list of vulnerabilities severities to be displayed      | `UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL` |
 | `scanner.trivy.ignoreUnfixed`         | The flag to display only fixed vulnerabilities                          | `false`        |
 | `scanner.trivy.skipUpdate`            | The flag to enable or disable Trivy DB downloads from GitHub            | `false`        |

--- a/helm/harbor-scanner-trivy/values.yaml
+++ b/helm/harbor-scanner-trivy/values.yaml
@@ -44,9 +44,13 @@ scanner:
   trivy:
     cacheDir: "/home/scanner/.cache/trivy"
     reportsDir: "/home/scanner/.cache/reports"
+    # debugMode the flag to enable Trivy debug mode
     debugMode: false
-    vulnType: "os"
+    # vulnType a comma-separated list of vulnerability types. Possible values are `os` and `library`.
+    vulnType: "os,library"
+    # severity a comma-separated list of vulnerabilities severities to be displayed
     severity: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
+    # ignoreUnfixed the flag to display only fixed vulnerabilities
     ignoreUnfixed: false
     # skipUpdate the flag to enable or disable Trivy DB downloads from GitHub
     #

--- a/pkg/etc/config.go
+++ b/pkg/etc/config.go
@@ -26,7 +26,7 @@ type Trivy struct {
 	CacheDir      string `env:"SCANNER_TRIVY_CACHE_DIR" envDefault:"/home/scanner/.cache/trivy"`
 	ReportsDir    string `env:"SCANNER_TRIVY_REPORTS_DIR" envDefault:"/home/scanner/.cache/reports"`
 	DebugMode     bool   `env:"SCANNER_TRIVY_DEBUG_MODE" envDefault:"false"`
-	VulnType      string `env:"SCANNER_TRIVY_VULN_TYPE" envDefault:"os"`
+	VulnType      string `env:"SCANNER_TRIVY_VULN_TYPE" envDefault:"os,library"`
 	Severity      string `env:"SCANNER_TRIVY_SEVERITY" envDefault:"UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"`
 	IgnoreUnfixed bool   `env:"SCANNER_TRIVY_IGNORE_UNFIXED" envDefault:"false"`
 	SkipUpdate    bool   `env:"SCANNER_TRIVY_SKIP_UPDATE" envDefault:"false"`

--- a/pkg/etc/config_test.go
+++ b/pkg/etc/config_test.go
@@ -1,13 +1,14 @@
 package etc
 
 import (
+	"os"
+	"testing"
+	"time"
+
 	"github.com/aquasecurity/harbor-scanner-trivy/pkg/model/harbor"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"os"
-	"testing"
-	"time"
 )
 
 type Envs map[string]string
@@ -65,7 +66,7 @@ func TestGetConfig(t *testing.T) {
 				Trivy: Trivy{
 					CacheDir:    "/home/scanner/.cache/trivy",
 					ReportsDir:  "/home/scanner/.cache/reports",
-					VulnType:    "os",
+					VulnType:    "os,library",
 					Severity:    "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL",
 					GitHubToken: "",
 				},

--- a/test/integration/api/rest_api_test.go
+++ b/test/integration/api/rest_api_test.go
@@ -11,10 +11,11 @@ import (
 	"testing"
 	"time"
 
+	v1 "github.com/aquasecurity/harbor-scanner-trivy/pkg/http/api/v1"
+
 	"github.com/aquasecurity/harbor-scanner-trivy/pkg/trivy"
 
 	"github.com/aquasecurity/harbor-scanner-trivy/pkg/etc"
-	v1 "github.com/aquasecurity/harbor-scanner-trivy/pkg/http/api/v1"
 	"github.com/aquasecurity/harbor-scanner-trivy/pkg/mock"
 	"github.com/aquasecurity/harbor-scanner-trivy/pkg/model/harbor"
 	"github.com/aquasecurity/harbor-scanner-trivy/pkg/model/job"
@@ -33,7 +34,13 @@ func TestRestApi(t *testing.T) {
 	store := mock.NewStore()
 	wrapper := trivy.NewMockWrapper()
 
-	app := v1.NewAPIHandler(etc.BuildInfo{Version: "1.0", Commit: "abc", Date: "2019-01-04T12:40"}, enqueuer, store, wrapper)
+	app := v1.NewAPIHandler(etc.BuildInfo{Version: "1.0", Commit: "abc", Date: "2019-01-04T12:40"}, etc.Config{Trivy: etc.Trivy{
+		SkipUpdate:    false,
+		IgnoreUnfixed: true,
+		DebugMode:     true,
+		VulnType:      "os,library",
+		Severity:      "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL",
+	}}, enqueuer, store, wrapper)
 
 	ts := httptest.NewServer(app)
 	defer ts.Close()
@@ -190,7 +197,12 @@ func TestRestApi(t *testing.T) {
     "org.label-schema.version": "1.0",
     "org.label-schema.build-date": "2019-01-04T12:40",
     "org.label-schema.vcs-ref": "abc",
-    "org.label-schema.vcs": "https://github.com/aquasecurity/harbor-scanner-trivy"
+    "org.label-schema.vcs": "https://github.com/aquasecurity/harbor-scanner-trivy",
+    "com.github.aquasecurity.trivy.skipUpdate": "false",
+    "com.github.aquasecurity.trivy.ignoreUnfixed": "true",
+    "com.github.aquasecurity.trivy.debugMode": "true",
+    "com.github.aquasecurity.trivy.vulnType": "os,library",
+    "com.github.aquasecurity.trivy.severity": "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
   }
 }`, string(bodyBytes))
 	})


### PR DESCRIPTION
We should not include the `harbor.scanner-adapter/vulnerability-database-next-update-at` in the metadata properties when the `SCANNER_TRIVY_SKIP_UPDATE` env is set to `true`.

<img width="1110" alt="fix_next_update_at" src="https://user-images.githubusercontent.com/1322923/77627421-286fd400-6f47-11ea-85b2-4bed94c3d541.png">

Also this PR introduced the following:

- Changed the default value of the `SCANNER_TRIVY_VULN_TYPE` env from `os` to `os,library`
- Added metadata properties to easily check adapter's config:
  - `com.github.aquasecurity.trivy.debugMode`
  - `com.github.aquasecurity.trivy.ignoreUnfixed`
  - `com.github.aquasecurity.trivy.severity`
  - `com.github.aquasecurity.trivy.skipUpdate`
  - `com.github.aquasecurity.trivy.vulnType`

/cc @simar7 