### PR TITLE
fix: Do not show DB update dates when not available

### DIFF
--- a/pkg/http/api/v1/handler.go
+++ b/pkg/http/api/v1/handler.go
@@ -221,11 +221,11 @@ func (h *requestHandler) GetMetadata(res http.ResponseWriter, _ *http.Request) {
 		log.WithError(err).Error("Error while retrieving vulnerability DB version")
 	}
 
-	if err == nil {
+	if err == nil && vi.VulnerabilityDB != nil {
 		properties[propertyDBUpdatedAt] = vi.VulnerabilityDB.UpdatedAt.Format(time.RFC3339)
 	}
 
-	if err == nil && !h.config.Trivy.SkipUpdate {
+	if err == nil && vi.VulnerabilityDB != nil && !h.config.Trivy.SkipUpdate {
 		properties[propertyDBNextUpdateAt] = vi.VulnerabilityDB.NextUpdate.Format(time.RFC3339)
 	}
 

--- a/pkg/http/api/v1/handler_test.go
+++ b/pkg/http/api/v1/handler_test.go
@@ -486,6 +486,51 @@ func TestRequestHandler_GetMetadata(t *testing.T) {
 }`,
 		},
 		{
+			name:            "Should respond with a valid Metadata JSON and HTTP 200 OK, when there's no trivy Metadata present",
+			mockedBuildInfo: etc.BuildInfo{Version: "0.1", Commit: "abc", Date: "2019-01-03T13:40"},
+			mockedVersion: trivy.VersionInfo{
+				Version: "v0.5.2-17-g3c9af62",
+			},
+			mockedConfig: etc.Config{Trivy: etc.Trivy{
+				SkipUpdate:    false,
+				IgnoreUnfixed: true,
+				DebugMode:     true,
+				VulnType:      "os,library",
+				Severity:      "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL",
+			}},
+			expectedHTTPCode: http.StatusOK,
+			expectedResp: `{
+   "scanner":{
+      "name":"Trivy",
+      "vendor":"Aqua Security",
+      "version":"Unknown"
+   },
+   "capabilities":[
+      {
+         "consumes_mime_types":[
+            "application/vnd.oci.image.manifest.v1+json",
+            "application/vnd.docker.distribution.manifest.v2+json"
+         ],
+         "produces_mime_types":[
+            "application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0"
+         ]
+      }
+   ],
+   "properties":{
+      "harbor.scanner-adapter/scanner-type": "os-package-vulnerability",
+      "org.label-schema.build-date": "2019-01-03T13:40",
+      "org.label-schema.vcs": "https://github.com/aquasecurity/harbor-scanner-trivy",
+      "org.label-schema.vcs-ref": "abc",
+      "org.label-schema.version": "0.1",
+      "com.github.aquasecurity.trivy.skipUpdate": "false",
+      "com.github.aquasecurity.trivy.ignoreUnfixed": "true",
+      "com.github.aquasecurity.trivy.debugMode": "true",
+      "com.github.aquasecurity.trivy.vulnType": "os,library",
+      "com.github.aquasecurity.trivy.severity": "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
+   }
+}`,
+		},
+		{
 			name:            "Should respond with a valid Metadata JSON and HTTP 200 OK when GetVersion fails",
 			mockedError:     errors.New("get version failed"),
 			mockedBuildInfo: etc.BuildInfo{Version: "0.1", Commit: "abc", Date: "2019-01-03T13:40"},

--- a/pkg/http/api/v1/handler_test.go
+++ b/pkg/http/api/v1/handler_test.go
@@ -438,8 +438,8 @@ func TestRequestHandler_GetMetadata(t *testing.T) {
 			name:            "Should respond with a valid Metadata JSON and HTTP 200 OK",
 			mockedBuildInfo: etc.BuildInfo{Version: "0.1", Commit: "abc", Date: "2019-01-03T13:40"},
 			mockedVersion: trivy.VersionInfo{
-				Trivy: "v0.5.2-17-g3c9af62",
-				VulnerabilityDB: trivy.Metadata{
+				Version: "v0.5.2-17-g3c9af62",
+				VulnerabilityDB: &trivy.Metadata{
 					NextUpdate: time.Unix(1584507644, 0).UTC(),
 					UpdatedAt:  time.Unix(1584517644, 0).UTC(),
 				},

--- a/pkg/trivy/model.go
+++ b/pkg/trivy/model.go
@@ -15,13 +15,13 @@ type ScanReport struct {
 }
 
 type Metadata struct {
-	NextUpdate time.Time
-	UpdatedAt  time.Time
+	NextUpdate time.Time `json:"NextUpdate"`
+	UpdatedAt  time.Time `json:"UpdatedAt"`
 }
 
 type VersionInfo struct {
-	Trivy           string   `json:",omitempty"`
-	VulnerabilityDB Metadata `json:",omitempty"`
+	Version         string    `json:"Version,omitempty"`
+	VulnerabilityDB *Metadata `json:"VulnerabilityDB"`
 }
 
 type Vulnerability struct {

--- a/pkg/trivy/wrapper_test.go
+++ b/pkg/trivy/wrapper_test.go
@@ -44,8 +44,8 @@ var (
 	}
 
 	expectedVersion = VersionInfo{
-		Trivy: "v0.5.2-17-g3c9af62",
-		VulnerabilityDB: Metadata{
+		Version: "v0.5.2-17-g3c9af62",
+		VulnerabilityDB: &Metadata{
 			NextUpdate: time.Unix(1584507644, 0).UTC(),
 			UpdatedAt:  time.Unix(1584517644, 0).UTC(),
 		},

--- a/test/integration/api/rest_api_test.go
+++ b/test/integration/api/rest_api_test.go
@@ -160,8 +160,8 @@ func TestRestApi(t *testing.T) {
 
 	t.Run("GET /api/v1/metadata", func(t *testing.T) {
 		wrapper.On("GetVersion").Return(trivy.VersionInfo{
-			Trivy: "v0.5.2-17-g3c9af62",
-			VulnerabilityDB: trivy.Metadata{
+			Version: "v0.5.2-17-g3c9af62",
+			VulnerabilityDB: &trivy.Metadata{
 				NextUpdate: time.Unix(1584507644, 0).UTC(),
 				UpdatedAt:  time.Unix(1584517644, 0).UTC(),
 			},


### PR DESCRIPTION
Related to https://github.com/goharbor/harbor/issues/11544

Fresh install of the adapter service does not trigger
the Trivy DB download. In such case the metadata
response returns a misleading default datetime.

This commit skips returning the default datetime
when the Trivy DB update dates areno t available.

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>