### PR TITLE
fix: Append port to image reference

### DIFF
--- a/pkg/harbor/model_test.go
+++ b/pkg/harbor/model_test.go
@@ -15,34 +15,21 @@ func TestScanRequest_GetImageRef(t *testing.T) {
 		expectedError    string
 	}{
 		{
-			name: "mongo",
+			name: "Should get imageRef when URL scheme is HTTP and port is not specified",
 			request: ScanRequest{
 				Registry: Registry{
-					URL: "https://core.harbor.domain",
+					URL: "http://core.harbor.domain",
 				},
 				Artifact: Artifact{
 					Repository: "library/mongo",
 					Digest:     "test:ABC",
 				},
 			},
-			expectedImageRef: "core.harbor.domain/library/mongo@test:ABC",
-			expectedInsecure: false,
+			expectedImageRef: "core.harbor.domain:80/library/mongo@test:ABC",
+			expectedInsecure: true,
 		},
 		{
-			name: "nginx",
-			request: ScanRequest{
-				Registry: Registry{
-					URL: "https://core.harbor.domain:443",
-				},
-				Artifact: Artifact{Repository: "library/nginx",
-					Digest: "test:DEF",
-				},
-			},
-			expectedImageRef: "core.harbor.domain:443/library/nginx@test:DEF",
-			expectedInsecure: false,
-		},
-		{
-			name: "harbor",
+			name: "Should get imageRef when URL scheme is HTTP and port is specified",
 			request: ScanRequest{
 				Registry: Registry{
 					URL: "http://harbor-harbor-registry:5000",
@@ -56,7 +43,35 @@ func TestScanRequest_GetImageRef(t *testing.T) {
 			expectedInsecure: true,
 		},
 		{
-			name: "invalid registry url",
+			name: "Should get imageRef when URL scheme is HTTPS and port is not specified",
+			request: ScanRequest{
+				Registry: Registry{
+					URL: "https://core.harbor.domain",
+				},
+				Artifact: Artifact{
+					Repository: "library/mongo",
+					Digest:     "test:ABC",
+				},
+			},
+			expectedImageRef: "core.harbor.domain:443/library/mongo@test:ABC",
+			expectedInsecure: false,
+		},
+		{
+			name: "Should get imageRef when URL scheme is HTTPS and port is specified",
+			request: ScanRequest{
+				Registry: Registry{
+					URL: "https://core.harbor.domain:8443",
+				},
+				Artifact: Artifact{Repository: "library/nginx",
+					Digest: "test:DEF",
+				},
+			},
+			expectedImageRef: "core.harbor.domain:8443/library/nginx@test:DEF",
+			expectedInsecure: false,
+		},
+
+		{
+			name: "Should return error when registry URL is invalid",
 			request: ScanRequest{
 				Registry: Registry{
 					URL: `"http://foo%bar@www.example.com/"`,

--- a/pkg/scan/controller_test.go
+++ b/pkg/scan/controller_test.go
@@ -62,7 +62,7 @@ func TestController_Scan(t *testing.T) {
 				Method: "Scan",
 				Args: []interface{}{
 					trivy.ImageRef{
-						Name:     "core.harbor.domain/library/mongo@sha256:917f5b7f4bef1b35ee90f03033f33a81002511c1e0767fd44276d4bd9cd2fa8e",
+						Name:     "core.harbor.domain:443/library/mongo@sha256:917f5b7f4bef1b35ee90f03033f33a81002511c1e0767fd44276d4bd9cd2fa8e",
 						Auth:     trivy.RegistryAuth{Username: "user", Password: "password"},
 						Insecure: false,
 					},
@@ -109,7 +109,7 @@ func TestController_Scan(t *testing.T) {
 				Method: "Scan",
 				Args: []interface{}{
 					trivy.ImageRef{
-						Name:     "core.harbor.domain/library/mongo@sha256:917f5b7f4bef1b35ee90f03033f33a81002511c1e0767fd44276d4bd9cd2fa8e",
+						Name:     "core.harbor.domain:443/library/mongo@sha256:917f5b7f4bef1b35ee90f03033f33a81002511c1e0767fd44276d4bd9cd2fa8e",
 						Auth:     trivy.RegistryAuth{Username: "user", Password: "password"},
 						Insecure: false,
 					},


### PR DESCRIPTION
When registry URL is specified as internal address Trivy
cannot resolve image reference and is trying to pull the
image from index.docker.io

This commit adds port 80 or 433 if it's not specified
in the registry URL.

Resolves: #108

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>