### PR TITLE
refactor: Inject dependencies to gocraft/work worker the right way

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,8 +39,9 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.txt
       - name: Release snapshot
-        uses: goreleaser/goreleaser-action@v1
+        uses: goreleaser/goreleaser-action@v2
         with:
+          version: v0.138.0
           args: release --snapshot --skip-publish --rm-dist
       - name: Scan image for vulnerabilities
         uses: docker://docker.io/aquasec/trivy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,8 @@ jobs:
           go-version: 1.14
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Unshallow # This step is required for the changelog to work correctly
-        run: git fetch --prune --unshallow
+        with:
+          fetch-depth: 0
       - name: Setup make
         run: make setup
       - name: Run linter
@@ -28,8 +28,9 @@ jobs:
         run: |
           echo ${{ secrets.DOCKERHUB_TOKEN }} | docker login --username ${{ secrets.DOCKERHUB_USER }} --password-stdin
       - name: Release
-        uses: goreleaser/goreleaser-action@v1
+        uses: goreleaser/goreleaser-action@v2
         with:
+          version: v0.138.0
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # That's the only place where you're supposed to specify or change version of Trivy.
-ARG TRIVY_VERSION=0.9.0
+ARG TRIVY_VERSION=0.9.1
 
 FROM aquasec/trivy:${TRIVY_VERSION}
 

--- a/pkg/scan/controller_test.go
+++ b/pkg/scan/controller_test.go
@@ -172,7 +172,7 @@ func TestController_ToRegistryAuth(t *testing.T) {
 		{
 			Name:          "Invalid auth",
 			Authorization: "Invalid someToken",
-			ExpectedAuth: nil,
+			ExpectedAuth:  nil,
 			ExpectedError: "unrecognized authorization type: Invalid",
 		},
 	}

--- a/test/component/component_test.go
+++ b/test/component/component_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	trivyScanner = harbor.Scanner{Name: "Trivy", Vendor: "Aqua Security", Version: "0.6.0"}
+	trivyScanner = harbor.Scanner{Name: "Trivy", Vendor: "Aqua Security", Version: "0.9.1"}
 )
 
 const (


### PR DESCRIPTION
This one solves also a subtle bug where we create a new Redis
connection pool for each scan job run.

Bumps up Trivy from v0.9.0 to v0.9.1.

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>