### PR TITLE
feat: Return envs as metadata properties

### DIFF
--- a/pkg/http/api/v1/handler.go
+++ b/pkg/http/api/v1/handler.go
@@ -209,12 +209,12 @@ func (h *requestHandler) GetMetadata(res http.ResponseWriter, _ *http.Request) {
 		"org.label-schema.vcs-ref":    h.info.Commit,
 		"org.label-schema.vcs":        "https://github.com/aquasecurity/harbor-scanner-trivy",
 
-		"com.github.aquasecurity.trivy.skipUpdate":    strconv.FormatBool(h.config.Trivy.SkipUpdate),
-		"com.github.aquasecurity.trivy.ignoreUnfixed": strconv.FormatBool(h.config.Trivy.IgnoreUnfixed),
-		"com.github.aquasecurity.trivy.debugMode":     strconv.FormatBool(h.config.Trivy.DebugMode),
-		"com.github.aquasecurity.trivy.insecure":      strconv.FormatBool(h.config.Trivy.Insecure),
-		"com.github.aquasecurity.trivy.vulnType":      h.config.Trivy.VulnType,
-		"com.github.aquasecurity.trivy.severity":      h.config.Trivy.Severity,
+		"env.SCANNER_TRIVY_SKIP_UPDATE":    strconv.FormatBool(h.config.Trivy.SkipUpdate),
+		"env.SCANNER_TRIVY_IGNORE_UNFIXED": strconv.FormatBool(h.config.Trivy.IgnoreUnfixed),
+		"env.SCANNER_TRIVY_DEBUG_MODE":     strconv.FormatBool(h.config.Trivy.DebugMode),
+		"env.SCANNER_TRIVY_INSECURE":       strconv.FormatBool(h.config.Trivy.Insecure),
+		"env.SCANNER_TRIVY_VULN_TYPE":      h.config.Trivy.VulnType,
+		"env.SCANNER_TRIVY_SEVERITY":       h.config.Trivy.Severity,
 	}
 
 	vi, err := h.wrapper.GetVersion()

--- a/pkg/http/api/v1/handler_test.go
+++ b/pkg/http/api/v1/handler_test.go
@@ -482,12 +482,12 @@ func TestRequestHandler_GetMetadata(t *testing.T) {
       "org.label-schema.vcs": "https://github.com/aquasecurity/harbor-scanner-trivy",
       "org.label-schema.vcs-ref": "abc",
       "org.label-schema.version": "0.1",
-      "com.github.aquasecurity.trivy.skipUpdate": "false",
-      "com.github.aquasecurity.trivy.ignoreUnfixed": "true",
-      "com.github.aquasecurity.trivy.debugMode": "true",
-      "com.github.aquasecurity.trivy.insecure": "true",
-      "com.github.aquasecurity.trivy.vulnType": "os,library",
-      "com.github.aquasecurity.trivy.severity": "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
+      "env.SCANNER_TRIVY_SKIP_UPDATE": "false",
+      "env.SCANNER_TRIVY_IGNORE_UNFIXED": "true",
+      "env.SCANNER_TRIVY_DEBUG_MODE": "true",
+      "env.SCANNER_TRIVY_INSECURE": "true",
+      "env.SCANNER_TRIVY_VULN_TYPE": "os,library",
+      "env.SCANNER_TRIVY_SEVERITY": "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
    }
 }`,
 		},
@@ -529,12 +529,12 @@ func TestRequestHandler_GetMetadata(t *testing.T) {
       "org.label-schema.vcs": "https://github.com/aquasecurity/harbor-scanner-trivy",
       "org.label-schema.vcs-ref": "abc",
       "org.label-schema.version": "0.1",
-      "com.github.aquasecurity.trivy.skipUpdate": "false",
-      "com.github.aquasecurity.trivy.ignoreUnfixed": "true",
-      "com.github.aquasecurity.trivy.debugMode": "true",
-      "com.github.aquasecurity.trivy.insecure": "true",
-      "com.github.aquasecurity.trivy.vulnType": "os,library",
-      "com.github.aquasecurity.trivy.severity": "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
+      "env.SCANNER_TRIVY_SKIP_UPDATE": "false",
+      "env.SCANNER_TRIVY_IGNORE_UNFIXED": "true",
+      "env.SCANNER_TRIVY_DEBUG_MODE": "true",
+      "env.SCANNER_TRIVY_INSECURE": "true",
+      "env.SCANNER_TRIVY_VULN_TYPE": "os,library",
+      "env.SCANNER_TRIVY_SEVERITY": "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
    }
 }`,
 		},
@@ -572,12 +572,12 @@ func TestRequestHandler_GetMetadata(t *testing.T) {
       "org.label-schema.vcs": "https://github.com/aquasecurity/harbor-scanner-trivy",
       "org.label-schema.vcs-ref": "abc",
       "org.label-schema.version": "0.1",
-      "com.github.aquasecurity.trivy.skipUpdate": "false",
-      "com.github.aquasecurity.trivy.ignoreUnfixed": "false",
-      "com.github.aquasecurity.trivy.debugMode": "false",
-      "com.github.aquasecurity.trivy.insecure": "false",
-      "com.github.aquasecurity.trivy.vulnType": "os,library",
-      "com.github.aquasecurity.trivy.severity": "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
+      "env.SCANNER_TRIVY_SKIP_UPDATE": "false",
+      "env.SCANNER_TRIVY_IGNORE_UNFIXED": "false",
+      "env.SCANNER_TRIVY_DEBUG_MODE": "false",
+      "env.SCANNER_TRIVY_INSECURE": "false",
+      "env.SCANNER_TRIVY_VULN_TYPE": "os,library",
+      "env.SCANNER_TRIVY_SEVERITY": "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
    }
 }`,
 		},

--- a/test/integration/api/rest_api_test.go
+++ b/test/integration/api/rest_api_test.go
@@ -212,12 +212,12 @@ func TestRestApi(t *testing.T) {
     "org.label-schema.build-date": "2019-01-04T12:40",
     "org.label-schema.vcs-ref": "abc",
     "org.label-schema.vcs": "https://github.com/aquasecurity/harbor-scanner-trivy",
-    "com.github.aquasecurity.trivy.skipUpdate": "false",
-    "com.github.aquasecurity.trivy.ignoreUnfixed": "true",
-    "com.github.aquasecurity.trivy.debugMode": "true",
-    "com.github.aquasecurity.trivy.insecure": "true",
-    "com.github.aquasecurity.trivy.vulnType": "os,library",
-    "com.github.aquasecurity.trivy.severity": "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
+    "env.SCANNER_TRIVY_SKIP_UPDATE": "false",
+    "env.SCANNER_TRIVY_IGNORE_UNFIXED": "true",
+    "env.SCANNER_TRIVY_DEBUG_MODE": "true",
+    "env.SCANNER_TRIVY_INSECURE": "true",
+    "env.SCANNER_TRIVY_VULN_TYPE": "os,library",
+    "env.SCANNER_TRIVY_SEVERITY": "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
   }
 }`, string(bodyBytes))
 	})


### PR DESCRIPTION
This is a little change in the way we return custom metadata properties to display and troubleshoot various adapter settings, which are passed to the Trivy scanner.

Before

![harbor-metadata-properties-before](https://user-images.githubusercontent.com/1322923/100539308-dbf73980-3235-11eb-961c-fca79da17b08.png)

After

![harbor-metadata-properties-after](https://user-images.githubusercontent.com/1322923/100539291-be29d480-3235-11eb-964c-cb403b3ac70c.png)

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>