### PR TITLE
chore: Downgrade Go from 1.15 to 1.14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.14
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Setup make

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.15
+          go-version: 1.14
       - name: Checkout code
         uses: actions/checkout@v2
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aquasecurity/harbor-scanner-trivy
 
-go 1.15
+go 1.14
 
 require (
 	github.com/FZambia/sentinel v1.1.0


### PR DESCRIPTION
Harbor 2.2 is still built with Go 1.14 because of the breaking change in Go 1.15.

- https://github.com/goharbor/harbor/pull/13326
- https://github.com/golang/go/issues/39568

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>