### PR TITLE
Bump trivy to 0.17.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # That's the only place where you're supposed to specify version of Trivy.
-ARG TRIVY_VERSION=0.16.0
+ARG TRIVY_VERSION=0.17.2
 
 FROM aquasec/trivy:${TRIVY_VERSION}
 

--- a/test/component/component_test.go
+++ b/test/component/component_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	trivyScanner = harbor.Scanner{Name: "Trivy", Vendor: "Aqua Security", Version: "0.16.0"}
+	trivyScanner = harbor.Scanner{Name: "Trivy", Vendor: "Aqua Security", Version: "0.17.2"}
 )
 
 const (


### PR DESCRIPTION
It would be great to release new version of adapter according to fresh Trivy release.