### PR TITLE
chore: Replace user and group IDs with 10000:10000

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM aquasec/trivy:${TRIVY_VERSION}
 # FROM use an ARG instruction without a value inside of a build stage.
 ARG TRIVY_VERSION
 
-RUN adduser -u 1000 -D -g '' scanner scanner
+RUN adduser -u 10000 -D -g '' scanner scanner
 
 COPY scanner-trivy /home/scanner/bin/scanner-trivy
 

--- a/helm/harbor-scanner-trivy/values.yaml
+++ b/helm/harbor-scanner-trivy/values.yaml
@@ -24,9 +24,9 @@ resources:
     memory: 1Gi
 
 podSecurityContext:
-  runAsUser: 1000
+  runAsUser: 10000
   runAsNonRoot: true
-  fsGroup: 1000
+  fsGroup: 10000
 
 securityContext:
   privileged: false


### PR DESCRIPTION
Replacing user and group IDs 1000:1000 with 10000:10000
makes this adapter service "compatible" with core Harbor
componens.

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>