### PR TITLE
Upgrade Trivy to v0.21.3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,16 +2,18 @@
 
 ## Table of Contents
 
-* [Set up Local Development Environment](#set-up-local-development-environment)
-* [Set up Development Environment with Vagrant](#setup-development-environment-with-vagrant)
-* [Build Binaries](#build-binaries)
-* [Test Scanner Adapter](#test-scanner-adapter)
-  * [Prerequisites](#prerequisites)
-  * [Update Container Image](#update-container-image)
-* [Run Tests](#run-tests)
-  * [Run Unit Tests](#run-unit-tests)
-  * [Run Integration Tests](#run-integration-tests)
-  * [Run Component Tests](#run-component-tests)
+- [Contributing](#contributing)
+  - [Table of Contents](#table-of-contents)
+  - [Set up Local Development Environment](#set-up-local-development-environment)
+  - [Setup Development Environment with Vagrant](#setup-development-environment-with-vagrant)
+  - [Build Binaries](#build-binaries)
+  - [Test Scanner Adapter](#test-scanner-adapter)
+    - [Prerequisites](#prerequisites)
+    - [Update Container Image](#update-container-image)
+  - [Run Tests](#run-tests)
+    - [Run Unit Tests](#run-unit-tests)
+    - [Run Integration Tests](#run-integration-tests)
+    - [Run Component Tests](#run-component-tests)
 
 ## Set up Local Development Environment
 
@@ -34,7 +36,7 @@
    cd harbor-scanner-trivy
    ```
 2. Create and configure a guest development machine, which is based on Ubuntu 20.4 LTS and has Go, Docker, Docker Compose,
-   Make, and Harbor v2.4.0 preinstalled. Harbor is installed in the `/opt/harbor` directory.
+   Make, and Harbor v2.4.1 preinstalled. Harbor is installed in the `/opt/harbor` directory.
    ```
    vagrant up
    ```
@@ -69,27 +71,27 @@ make docker-build
 
 ### Prerequisites
 
-Install Harbor with [Harbor installer](https://goharbor.io/docs/2.3.0/install-config/download-installer/).
+Install Harbor with [Harbor installer](https://goharbor.io/docs/2.4.0/install-config/download-installer/).
 Make sure that you install Harbor with Trivy, i.e. `sudo ./install.sh --with-trivy`.
 
 ```console
 $ docker ps
-CONTAINER ID   IMAGE                                  COMMAND                  CREATED          STATUS                    PORTS                                   NAMES
-c4acd5694606   goharbor/nginx-photon:v2.3.2           "nginx -g 'daemon of…"   32 seconds ago   Up 31 seconds (healthy)   0.0.0.0:80->8080/tcp, :::80->8080/tcp   nginx
-c6060e31d2e3   goharbor/harbor-jobservice:v2.3.2      "/harbor/entrypoint.…"   32 seconds ago   Up 31 seconds (healthy)                                           harbor-jobservice
-878cc280e634   goharbor/trivy-adapter-photon:v2.3.2   "/home/scanner/entry…"   32 seconds ago   Up 32 seconds (healthy)                                           trivy-adapter
-377922e00aa1   goharbor/harbor-core:v2.3.2            "/harbor/entrypoint.…"   32 seconds ago   Up 32 seconds (healthy)                                           harbor-core
-c8530be38c0c   goharbor/harbor-registryctl:v2.3.2     "/home/harbor/start.…"   33 seconds ago   Up 33 seconds (healthy)                                           registryctl
-fa6015b28ea7   goharbor/harbor-db:v2.3.2              "/docker-entrypoint.…"   33 seconds ago   Up 32 seconds (healthy)                                           harbor-db
-acb198e326f7   goharbor/registry-photon:v2.3.2        "/home/harbor/entryp…"   33 seconds ago   Up 32 seconds (healthy)                                           registry
-fb445cb08b1c   goharbor/harbor-portal:v2.3.2          "nginx -g 'daemon of…"   33 seconds ago   Up 32 seconds (healthy)                                           harbor-portal
-34f4ed9a3ac1   goharbor/redis-photon:v2.3.2           "redis-server /etc/r…"   33 seconds ago   Up 32 seconds (healthy)                                           redis
-157a023611ae   goharbor/harbor-log:v2.3.2             "/bin/sh -c /usr/loc…"   34 seconds ago   Up 33 seconds (healthy)   127.0.0.1:1514->10514/tcp               harbor-log
+CONTAINER ID   IMAGE                                  COMMAND                  CREATED              STATUS                        PORTS                                   NAMES
+afd1962f5099   goharbor/nginx-photon:v2.4.1           "nginx -g 'daemon of…"   About a minute ago   Up About a minute (healthy)   0.0.0.0:80->8080/tcp, :::80->8080/tcp   nginx
+a7d9433af1e3   goharbor/harbor-jobservice:v2.4.1      "/harbor/entrypoint.…"   About a minute ago   Up About a minute (healthy)                                           harbor-jobservice
+a6f70ddcac58   goharbor/trivy-adapter-photon:v2.4.1   "/home/scanner/entry…"   About a minute ago   Up About a minute (healthy)                                           trivy-adapter
+d8eb086391d1   goharbor/harbor-core:v2.4.1            "/harbor/entrypoint.…"   About a minute ago   Up About a minute (healthy)                                           harbor-core
+8d8f7809c673   goharbor/redis-photon:v2.4.1           "redis-server /etc/r…"   About a minute ago   Up About a minute (healthy)                                           redis
+733de91f5470   goharbor/harbor-registryctl:v2.4.1     "/home/harbor/start.…"   About a minute ago   Up About a minute (healthy)                                           registryctl
+733e7ba95f3f   goharbor/harbor-db:v2.4.1              "/docker-entrypoint.…"   About a minute ago   Up About a minute (healthy)                                           harbor-db
+0a51213cb9ed   goharbor/harbor-portal:v2.4.1          "nginx -g 'daemon of…"   About a minute ago   Up About a minute (healthy)                                           harbor-portal
+69ed0584eb4f   goharbor/registry-photon:v2.4.1        "/home/harbor/entryp…"   About a minute ago   Up About a minute (healthy)                                           registry
+c0db2b828f89   goharbor/harbor-log:v2.4.1             "/bin/sh -c /usr/loc…"   About a minute ago   Up About a minute (healthy)   127.0.0.1:1514->10514/tcp               harbor-log
 ```
 
 ### Update Container Image
 
-1. Navigate to Harbor installation directory.
+1. Navigate to Harbor installation directory (`/opt/harbor`).
 2. Stop Harbor services.
    ```
    sudo docker-compose down

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # That's the only place where you're supposed to specify version of Trivy.
-ARG TRIVY_VERSION=0.20.1
+ARG TRIVY_VERSION=0.21.3
 
 FROM aquasec/trivy:${TRIVY_VERSION}
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The following matrix indicates the version of Trivy and Trivy adapter installed 
 
 | Harbor          | Trivy Adapter | Trivy           |
 |-----------------|---------------|-----------------|
+| [harbor v2.4.1] | v0.25.0       | [trivy v0.21.3] |
 | [harbor v2.4.0] | v0.24.0       | [trivy v0.20.1] |
 | -               | v0.23.0       | [trivy v0.20.0] |
 | -               | v0.22.0       | [trivy v0.19.2] |
@@ -51,6 +52,7 @@ The following matrix indicates the version of Trivy and Trivy adapter installed 
 | [harbor v2.1.6] | v0.14.1       | [trivy v0.9.2]  |
 | [harbor v2.1.0] | v0.14.1       | [trivy v0.9.2]  |
 
+[harbor v2.4.1]: https://github.com/goharbor/harbor/releases/tag/v2.4.1
 [harbor v2.4.0]: https://github.com/goharbor/harbor/releases/tag/v2.4.0
 [harbor v2.3.3]: https://github.com/goharbor/harbor/releases/tag/v2.3.3
 [harbor v2.3.0]: https://github.com/goharbor/harbor/releases/tag/v2.3.0

--- a/helm/harbor-scanner-trivy/Chart.yaml
+++ b/helm/harbor-scanner-trivy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: harbor-scanner-trivy
-version: 0.24.0
-appVersion: 0.24.0
+version: 0.25.0
+appVersion: 0.25.0
 description: Harbor scanner adapter for Trivy
 keywords:
   - scanner

--- a/helm/harbor-scanner-trivy/values.yaml
+++ b/helm/harbor-scanner-trivy/values.yaml
@@ -4,7 +4,7 @@ fullnameOverride: ""
 image:
   registry: docker.io
   repository: aquasec/harbor-scanner-trivy
-  tag: 0.24.0
+  tag: 0.25.0
   pullPolicy: IfNotPresent
 
 replicaCount: 1

--- a/test/component/component_test.go
+++ b/test/component/component_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	trivyScanner = harbor.Scanner{Name: "Trivy", Vendor: "Aqua Security", Version: "0.20.1"}
+	trivyScanner = harbor.Scanner{Name: "Trivy", Vendor: "Aqua Security", Version: "0.21.3"}
 )
 
 const (
@@ -69,7 +69,7 @@ func TestComponent(t *testing.T) {
 
 	redisC, err := dp.CreateContainer(ctx,
 		tc.ContainerRequest{
-			Name:       "redis",
+			Name:       "redis-comp-test",
 			Image:      "redis:5",
 			Networks:   []string{testNetwork},
 			WaitingFor: wait.ForLog("Ready to accept connections"),
@@ -81,7 +81,7 @@ func TestComponent(t *testing.T) {
 
 	registryC, err := dp.CreateContainer(ctx,
 		tc.ContainerRequest{
-			Name:         "registry",
+			Name:         "registry-comp-test",
 			Image:        registryImage,
 			Networks:     []string{testNetwork},
 			ExposedPorts: []string{registryPort},
@@ -106,7 +106,7 @@ func TestComponent(t *testing.T) {
 	defer func() { _ = registryC.Terminate(ctx) }()
 
 	adapterC, err := dp.CreateContainer(ctx, tc.ContainerRequest{
-		Name:         "trivy-adapter",
+		Name:         "trivy-adapter-comp-test",
 		Image:        adapterImage,
 		Networks:     []string{testNetwork},
 		ExposedPorts: []string{adapterPort},

--- a/vagrant/install-harbor.sh
+++ b/vagrant/install-harbor.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-HARBOR_VERSION="v2.4.0"
+HARBOR_VERSION="v2.4.1"
 
 # Keep in sync with vagrant/harbor.yml.
 HARBOR_HOSTNAME="harbor.dev.io"


### PR DESCRIPTION
Hi guys,

Inside this PR, I upgraded Trivy to version `v0.21.3`. Harbor was also upgraded to the next patch version (`v2.4.1`).

I think it needs some further testing from your side, especially since the `make test-component` command currently fails (`make test` and `make test-integration` runs just fine):
```bash
vagrant@ubuntu-focal:/vagrant$ make test-component
GOOS=linux GO111MODULE=on CGO_ENABLED=0 go build -o scanner-trivy cmd/scanner-trivy/main.go
docker build --no-cache -t aquasec/harbor-scanner-trivy:dev .
Sending build context to Docker daemon  46.91MB
Step 1/8 : ARG TRIVY_VERSION=0.21.3
Step 2/8 : FROM aquasec/trivy:${TRIVY_VERSION}
 ---> c28c291ad36e
Step 3/8 : ARG TRIVY_VERSION
 ---> Running in 60f7a8ca7a21
Removing intermediate container 60f7a8ca7a21
 ---> 41e569477c1e
Step 4/8 : RUN adduser -u 10000 -D -g '' scanner scanner
 ---> Running in be5452229b99
Removing intermediate container be5452229b99
 ---> 8dd1e1ffcf6d
Step 5/8 : COPY scanner-trivy /home/scanner/bin/scanner-trivy
 ---> 5a9017706aaa
Step 6/8 : ENV TRIVY_VERSION=${TRIVY_VERSION}
 ---> Running in eeb6e3bffad1
Removing intermediate container eeb6e3bffad1
 ---> 0b47b7a24302
Step 7/8 : USER scanner
 ---> Running in 6e07c21fe43d
Removing intermediate container 6e07c21fe43d
 ---> a7a4b0b73931
Step 8/8 : ENTRYPOINT ["/home/scanner/bin/scanner-trivy"]
 ---> Running in 4f39359b6994
Removing intermediate container 4f39359b6994
 ---> 5eaf0bfba27a
Successfully built 5eaf0bfba27a
Successfully tagged aquasec/harbor-scanner-trivy:dev
GO111MODULE=on go test -count=1 -v -tags=component ./test/component/...
=== RUN   TestComponent
2021/12/24 13:00:36 Starting container id: d48e555d5bd2 image: quay.io/testcontainers/ryuk:0.2.3
2021/12/24 13:00:37 Waiting for container id d48e555d5bd2 image: quay.io/testcontainers/ryuk:0.2.3
2021/12/24 13:00:37 Container is ready id: d48e555d5bd2 image: quay.io/testcontainers/ryuk:0.2.3
2021/12/24 13:00:37 Starting container id: a4882660bf98 image: redis:5
2021/12/24 13:00:38 Waiting for container id a4882660bf98 image: redis:5
2021/12/24 13:00:38 Container is ready id: a4882660bf98 image: redis:5
2021/12/24 13:00:43 Starting container id: f655b67ff925 image: registry:2
2021/12/24 13:00:44 Waiting for container id f655b67ff925 image: registry:2
2021/12/24 13:00:45 Container is ready id: f655b67ff925 image: registry:2
2021/12/24 13:00:45 Starting container id: a62d71d0f3b9 image: aquasec/harbor-scanner-trivy:dev
2021/12/24 13:00:45 Waiting for container id a62d71d0f3b9 image: aquasec/harbor-scanner-trivy:dev
2021/12/24 13:00:54 Container is ready id: a62d71d0f3b9 image: aquasec/harbor-scanner-trivy:dev
=== RUN   TestComponent/Should_scan_alpine:3.14
    component_test.go:180:
        	Error Trace:	component_test.go:180
        	Error:      	Received unexpected error:
        	            	invalid response status: 500 500 Internal Server Error
        	Test:       	TestComponent/Should_scan_alpine:3.14
=== CONT  TestComponent
    component_test.go:131: adatper logs
        [{"built_at":"unknown","commit":"none","level":"info","msg":"Starting harbor-scanner-trivy","time":"2021-12-24T13:00:45Z","version":"dev"}
         {"level":"debug","msg":"Current process","pid":1,"time":"2021-12-24T13:00:45Z"}
         {"gid":10000,"home_dir":"/home/scanner","level":"debug","msg":"Current user","time":"2021-12-24T13:00:45Z","uid":10000}
         {"level":"warning","msg":"trivy cache dir does not exist","path":"/home/scanner/.cache/trivy","time":"2021-12-24T13:00:45Z"}
         {"level":"debug","msg":"Creating trivy cache dir","path":"/home/scanner/.cache/trivy","time":"2021-12-24T13:00:45Z"}
         {"level":"debug","mode":"dgrwxr-xr-x","msg":"trivy cache dir permissions","time":"2021-12-24T13:00:45Z"}
         {"level":"warning","msg":"trivy reports dir does not exist","path":"/home/scanner/.cache/reports","time":"2021-12-24T13:00:45Z"}
         {"level":"debug","msg":"Creating trivy reports dir","path":"/home/scanner/.cache/reports","time":"2021-12-24T13:00:45Z"}
         {"level":"debug","mode":"dgrwxr-xr-x","msg":"trivy reports dir permissions","time":"2021-12-24T13:00:45Z"}
         {"level":"trace","msg":"Connecting to Redis","time":"2021-12-24T13:00:45Z","url":"redis://redis:6379"}
         ERROR: write_concurrency_controls_max_concurrency - dial tcp: lookup redis on 127.0.0.11:53: no such host
         {"addr":":8080","level":"warning","msg":"Starting API server without TLS","time":"2021-12-24T13:00:53Z"}
         {"level":"trace","msg":"Connecting to Redis","time":"2021-12-24T13:00:53Z","url":"redis://redis:6379"}
         {"level":"trace","msg":"Connecting to Redis","time":"2021-12-24T13:00:53Z","url":"redis://redis:6379"}
         {"level":"trace","msg":"Connecting to Redis","time":"2021-12-24T13:00:53Z","url":"redis://redis:6379"}
         {"level":"trace","msg":"Connecting to Redis","time":"2021-12-24T13:00:53Z","url":"redis://redis:6379"}
         {"level":"trace","msg":"Connecting to Redis","time":"2021-12-24T13:00:54Z","url":"redis://redis:6379"}
         {"level":"trace","msg":"172.20.0.1:34184 - HTTP/1.1 POST /api/v1/scan","time":"2021-12-24T13:00:58Z"}
         {"level":"debug","msg":"Enqueueing scan job","time":"2021-12-24T13:00:58Z"}
        ]
--- FAIL: TestComponent (51.08s)
    --- FAIL: TestComponent/Should_scan_alpine:3.14 (15.93s)
FAIL
FAIL	github.com/aquasecurity/harbor-scanner-trivy/test/component	51.100s
?   	github.com/aquasecurity/harbor-scanner-trivy/test/component/docker	[no test files]
?   	github.com/aquasecurity/harbor-scanner-trivy/test/component/scanner	[no test files]
FAIL
make: *** [Makefile:17: test-component] Error 1
```

Also interesting was, that a manual testing of some sample images (`alpine:3.14` and `elasticsearch:6.8.14`) worked like a charm:
 
![image](https://user-images.githubusercontent.com/5549063/147355815-f28674e3-c5e3-4e06-95a7-d6b5564335c0.png)
![image](https://user-images.githubusercontent.com/5549063/147355846-a0343c2b-6b89-4094-a310-d577ccf956ae.png)
![image](https://user-images.githubusercontent.com/5549063/147355861-5c90e44b-c06f-4605-a516-d87e2a17d125.png)

I think it's a more a failure in the `test-component` setup than a broken setup because of the new Trivy / Harbor version.

BTW, with this new Trivy version, even the log4shell CVEs were now detected and directly reported to Harbor:

![image](https://user-images.githubusercontent.com/5549063/147355906-00b16d45-c452-4274-ab97-72cbf368b935.png)

Thanks & regards,
Philip