### PR TITLE
Update Trivy to 0.22.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # That's the only place where you're supposed to specify version of Trivy.
-ARG TRIVY_VERSION=0.20.1
+ARG TRIVY_VERSION=0.22.0
 
 FROM aquasec/trivy:${TRIVY_VERSION}
 

--- a/test/component/component_test.go
+++ b/test/component/component_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	trivyScanner = harbor.Scanner{Name: "Trivy", Vendor: "Aqua Security", Version: "0.20.1"}
+	trivyScanner = harbor.Scanner{Name: "Trivy", Vendor: "Aqua Security", Version: "0.22.0"}
 )
 
 const (


### PR DESCRIPTION
Hey guys,

This micro-PR simply updates the version of Trivy bundled in the harbor adapter from 0.20.1 (Oct 2020) to the latest (0.22.0).

Cheers! :)
D