### PR TITLE
Update model.go

### DIFF
--- a/pkg/harbor/model.go
+++ b/pkg/harbor/model.go
@@ -85,15 +85,7 @@ func (c ScanRequest) GetImageRef() (imageRef string, insecureRegistry bool, err 
 		return
 	}
 
-	port := registryURL.Port()
-	if port == "" && registryURL.Scheme == "http" {
-		port = "80"
-	}
-	if port == "" && registryURL.Scheme == "https" {
-		port = "443"
-	}
-
-	imageRef = fmt.Sprintf("%s:%s/%s@%s", registryURL.Hostname(), port, c.Artifact.Repository, c.Artifact.Digest)
+	imageRef = fmt.Sprintf("%s/%s@%s", registryURL.Host, c.Artifact.Repository, c.Artifact.Digest)
 	insecureRegistry = "http" == registryURL.Scheme
 	return
 }


### PR DESCRIPTION
443和80带端口,在扫描镜像的时候,报错:
trivy unable to initialize a docker scanner