### PR TITLE
Allow dbRepository variable in harbor-scanner-trivy

### DIFF
--- a/helm/harbor-scanner-trivy/templates/statefulset.yaml
+++ b/helm/harbor-scanner-trivy/templates/statefulset.yaml
@@ -73,6 +73,8 @@ spec:
               value: {{ .Values.scanner.trivy.timeout | quote }}
             - name: "SCANNER_TRIVY_SKIP_UPDATE"
               value: {{ .Values.scanner.trivy.skipUpdate | quote }}
+            - name: "TRIVY_DB_REPOSITORY"
+              value: {{ .Values.trivy.dbRepository | quote }}
             - name: "SCANNER_TRIVY_OFFLINE_SCAN"
               value: {{ .Values.scanner.trivy.offlineScan | quote }}
             - name: "SCANNER_TRIVY_GITHUB_TOKEN"

--- a/helm/harbor-scanner-trivy/values.yaml
+++ b/helm/harbor-scanner-trivy/values.yaml
@@ -74,6 +74,8 @@ scanner:
     ## If the flag is enabled you have to manually download the `trivy.db` file and mount it in the
     ## `/home/scanner/.cache/trivy/db/trivy.db` path (see `cacheDir`).
     skipUpdate: false
+    # OCI repository to retrieve the trivy vulnerability database from
+    dbRepository: ghcr.io/aquasecurity/trivy-db
     # offlineScan the flag to disable external API requests to identify dependencies.
     offlineScan: false
     ## gitHubToken the GitHub access token to download Trivy DB


### PR DESCRIPTION
First time contributor to this project, let me know if there is anything you want me to do in addition to this.

This feature was implemented on the main Trivy Helm chart and it allows you to specify the OCI compliant repository where the db update files are.

