### PR TITLE
chore: auto bump-go-version release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20.5
+          go-version-file: go.mod
       - name: Checkout code
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
chore: auto bump-go-version release