### PR TITLE
chore(deps): bump trivy to v0.48.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # That's the only place where you're supposed to specify version of Trivy.
-ARG TRIVY_VERSION=0.48.1
+ARG TRIVY_VERSION=0.48.3
 
 FROM aquasec/trivy:${TRIVY_VERSION}
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The following matrix indicates the version of Trivy and Trivy adapter installed 
 
 | Harbor           | Trivy Adapter | Trivy           |
 |------------------|---------------|-----------------|
+| -                | v0.30.21      | [trivy v0.48.3] |
 | -                | v0.30.20      | [trivy v0.48.1] |
 | -                | v0.30.19      | [trivy v0.47.0] |
 | -                | v0.30.18      | [trivy v0.46.1] |

--- a/test/component/component_test.go
+++ b/test/component/component_test.go
@@ -21,7 +21,11 @@ import (
 )
 
 var (
-	trivyScanner = harbor.Scanner{Name: "Trivy", Vendor: "Aqua Security", Version: "0.48.1"}
+	trivyScanner = harbor.Scanner{
+		Name:    "Trivy",
+		Vendor:  "Aqua Security",
+		Version: "0.48.3",
+	}
 )
 
 const (


### PR DESCRIPTION
v0.48.3 contains several security fixes in dependencies.