### PR TITLE
Remove Scanner reference in Helm install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,7 @@ helm repo add harbor https://helm.goharbor.io
 ```
 helm install harbor harbor/harbor \
   --create-namespace \
-  --namespace harbor \
-  --set clair.enabled=false \
-  --set trivy.enabled=true
+  --namespace harbor
 ```
 
 The adapter service is automatically registered under the **Interrogation Service** in the Harbor interface and


### PR DESCRIPTION
There is no option to select the Scanner in the Helm Chart, the default installation will install Trivy